### PR TITLE
Fix logic connector copy/paste state, stale redstone outputs, and facaded connector light blocking

### DIFF
--- a/src/main/java/mcjty/xnet/api/helper/AbstractConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/api/helper/AbstractConnectorSettings.java
@@ -171,6 +171,7 @@ public abstract class AbstractConnectorSettings implements IConnectorSettings {
         colors[1] = getEnumSafe(object, "color1", EnumStringTranslators::getColor);
         colors[2] = getEnumSafe(object, "color2", EnumStringTranslators::getColor);
         colors[3] = getEnumSafe(object, "color3", EnumStringTranslators::getColor);
+        calculateColorsMask();
         facingOverride = getEnumSafe(object, "facingoverride", EnumFacing::byName);
     }
 

--- a/src/main/java/mcjty/xnet/apiimpl/logic/LogicConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/logic/LogicConnectorSettings.java
@@ -182,6 +182,7 @@ public class LogicConnectorSettings extends AbstractConnectorSettings {
         super.writeToJsonInternal(object);
         setEnumSafe(object, "logicmode", logicMode);
         setIntegerSafe(object, "speed", speed);
+        setIntegerSafe(object, TAG_REDSTONE_OUT, redstoneOut);
         JsonArray sensorArray = new JsonArray();
         for (Sensor sensor : sensors) {
             JsonObject o = new JsonObject();
@@ -206,6 +207,7 @@ public class LogicConnectorSettings extends AbstractConnectorSettings {
         super.readFromJsonInternal(object);
         logicMode = getEnumSafe(object, "logicmode", EnumStringTranslators::getLogicMode);
         speed = getIntegerNotNull(object, "speed");
+        redstoneOut = getIntegerSafe(object, TAG_REDSTONE_OUT);
         JsonArray sensorArray = object.get("sensors").getAsJsonArray();
         sensors.clear();
         for (JsonElement oe : sensorArray) {

--- a/src/main/java/mcjty/xnet/blocks/cables/ConnectorBlock.java
+++ b/src/main/java/mcjty/xnet/blocks/cables/ConnectorBlock.java
@@ -26,7 +26,10 @@ import mcjty.xnet.multiblock.XNetBlobData;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.client.util.ITooltipFlag;
@@ -47,7 +50,9 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
+import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.Optional;
@@ -61,7 +66,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 public class ConnectorBlock extends GenericCableBlock implements ITileEntityProvider {
-
+    public static final PropertyBool FACADE = PropertyBool.create("facade");
     public static final String CONNECTOR = "connector";
 
     public ConnectorBlock() {
@@ -71,6 +76,7 @@ public class ConnectorBlock extends GenericCableBlock implements ITileEntityProv
     public ConnectorBlock(String name) {
         super(Material.IRON, name);
         initTileEntity();
+        setDefaultState(getDefaultState().withProperty(FACADE, false));
     }
 
     protected void initTileEntity() {
@@ -85,8 +91,44 @@ public class ConnectorBlock extends GenericCableBlock implements ITileEntityProv
             }
         }
     }
+    @Override
+    @SuppressWarnings("deprecation")
+    public int getLightOpacity(IBlockState state, IBlockAccess world, BlockPos pos) {
+        if (!state.getValue(FACADE)) {
+            return 0;
+        }
 
+        IBlockState mimicBlock = getMimicBlock(world, pos);
+        if (mimicBlock != null) {
+            return mimicBlock.getLightOpacity(world, pos);
+        }
 
+        return 255;
+    }
+    @Override
+    protected BlockStateContainer createBlockState() {
+        IProperty<?>[] listedProperties = new IProperty<?>[] { COLOR, FACADE };
+        IUnlistedProperty<?>[] unlistedProperties = new IUnlistedProperty<?>[] {
+                NORTH, SOUTH, WEST, EAST, UP, DOWN, FACADEID
+        };
+        return new ExtendedBlockState(this, listedProperties, unlistedProperties);
+    }
+
+    @Override
+    public IBlockState getStateFromMeta(int meta) {
+        CableColor color = CableColor.VALUES[meta & 0x7];
+        boolean facade = (meta & 0x8) != 0;
+        return getDefaultState().withProperty(COLOR, color).withProperty(FACADE, facade);
+    }
+
+    @Override
+    public int getMetaFromState(IBlockState state) {
+        int meta = state.getValue(COLOR).ordinal();
+        if (state.getValue(FACADE)) {
+            meta |= 0x8;
+        }
+        return meta;
+    }
     @Override
     public TileEntity createNewTileEntity(World world, int i) {
         return null;

--- a/src/main/java/mcjty/xnet/blocks/cables/ConnectorTileEntity.java
+++ b/src/main/java/mcjty/xnet/blocks/cables/ConnectorTileEntity.java
@@ -106,6 +106,19 @@ public class ConnectorTileEntity extends GenericTileEntity implements IFacadeSup
     public void setMimicBlock(IBlockState mimicBlock) {
         mimicBlockSupport.setMimicBlock(mimicBlock);
         markDirtyClient();
+
+        if (world != null && !world.isRemote) {
+            IBlockState state = world.getBlockState(pos);
+            if (state.getBlock() instanceof ConnectorBlock) {
+                boolean facaded = mimicBlock != null;
+                if (state.getValue(ConnectorBlock.FACADE) != facaded) {
+                    world.setBlockState(pos, state.withProperty(ConnectorBlock.FACADE, facaded), 3);
+                    state = world.getBlockState(pos);
+                }
+            }
+            world.notifyBlockUpdate(pos, state, state, 3);
+            world.checkLight(pos);
+        }
     }
 
     @Override

--- a/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
@@ -23,6 +23,7 @@ import mcjty.xnet.api.keys.SidedConsumer;
 import mcjty.xnet.api.keys.SidedPos;
 import mcjty.xnet.apiimpl.fluids.FluidConnectorSettings;
 import mcjty.xnet.apiimpl.items.ItemConnectorSettings;
+import mcjty.xnet.apiimpl.logic.LogicConnectorSettings;
 import mcjty.xnet.blocks.cables.ConnectorBlock;
 import mcjty.xnet.blocks.cables.ConnectorTileEntity;
 import mcjty.xnet.blocks.cables.NetCableSetup;
@@ -287,6 +288,60 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
         }
     }
 
+    private void clearOutput(SidedConsumer consumer) {
+        BlockPos connectorPos = findConsumerPosition(consumer.getConsumerId());
+        if (connectorPos == null || !getWorld().isBlockLoaded(connectorPos)) {
+            return;
+        }
+        TileEntity te = getWorld().getTileEntity(connectorPos);
+        if (te instanceof ConnectorTileEntity) {
+            ((ConnectorTileEntity) te).setPowerOut(consumer.getSide(), 0);
+        }
+    }
+
+    private boolean isLogicOutput(@Nullable IConnectorSettings settings) {
+        return settings instanceof LogicConnectorSettings
+                && ((LogicConnectorSettings) settings).getLogicMode() == LogicConnectorSettings.LogicMode.OUTPUT;
+    }
+
+    private void clearIfLogicOutput(SidedConsumer consumer, @Nullable IConnectorSettings settings) {
+        if (isLogicOutput(settings)) {
+            clearOutput(consumer);
+        }
+    }
+
+    private void collectConfiguredLogicOutputs(@Nullable Map<SidedConsumer, ConnectorInfo> connectors, Set<SidedConsumer> out) {
+        if (connectors == null) {
+            return;
+        }
+        for (Map.Entry<SidedConsumer, ConnectorInfo> entry : connectors.entrySet()) {
+            if (isLogicOutput(entry.getValue().getConnectorSettings())) {
+                out.add(entry.getKey());
+            }
+        }
+    }
+    private void collectConfiguredLogicOutputsFromRuntime(int channel, Set<SidedConsumer> out) {
+        Map<SidedConsumer, IConnectorSettings> routed = getRoutedConnectors(channel);
+        for (Map.Entry<SidedConsumer, IConnectorSettings> entry : routed.entrySet()) {
+            if (isLogicOutput(entry.getValue())) {
+                out.add(entry.getKey());
+            }
+        }
+    }
+
+    private void clearChannelOutputs(int channel) {
+        if (channels[channel] == null) {
+            return;
+        }
+        Set<SidedConsumer> toClear = new HashSet<>();
+        collectConfiguredLogicOutputs(channels[channel].getConnectors(), toClear);
+        collectConfiguredLogicOutputsFromRuntime(channel, toClear);
+
+        for (SidedConsumer consumer : toClear) {
+            clearOutput(consumer);
+        }
+    }
+
     private void cleanCache(int channel) {
         cachedConnectors[channel] = null;
         cachedRoutedConnectors[channel] = null;
@@ -513,10 +568,16 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
         for (Key<?> key : params.getKeys()) {
             data.put(key.getName(), params.get(key));
         }
+
+        boolean oldEnabled = channels[channel].isEnabled();
         channels[channel].getChannelSettings().update(data);
 
         Boolean enabled = (Boolean) data.get(GuiController.TAG_ENABLED);
-        channels[channel].setEnabled(Boolean.TRUE.equals(enabled));
+        boolean newEnabled = Boolean.TRUE.equals(enabled);
+        if (oldEnabled && !newEnabled) {
+            clearChannelOutputs(channel);
+        }
+        channels[channel].setEnabled(newEnabled);
 
         String name = (String) data.get(GuiController.TAG_NAME);
         channels[channel].setChannelName(name);
@@ -530,6 +591,7 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
     }
 
     private void removeChannel(int channel) {
+        clearChannelOutputs(channel);
         channels[channel] = null;
         cachedConnectors[channel] = null;
         cachedRoutedConnectors[channel] = null;
@@ -553,8 +615,22 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
                 for (Key<?> k : params.getKeys()) {
                     data.put(k.getName(), params.get(k));
                 }
-                connectorInfo.getConnectorSettings().update(data);
-                connectorInfo.getConnectorSettings().sanitizeSettings(connectorInfo.isAdvanced());
+
+                IConnectorSettings settings = connectorInfo.getConnectorSettings();
+                LogicConnectorSettings.LogicMode oldMode = null;
+                if (settings instanceof LogicConnectorSettings) {
+                    oldMode = ((LogicConnectorSettings) settings).getLogicMode();
+                }
+
+                settings.update(data);
+                settings.sanitizeSettings(connectorInfo.isAdvanced());
+
+                if (settings instanceof LogicConnectorSettings
+                        && oldMode == LogicConnectorSettings.LogicMode.OUTPUT
+                        && ((LogicConnectorSettings) settings).getLogicMode() != LogicConnectorSettings.LogicMode.OUTPUT) {
+                    clearOutput(key);
+                }
+
                 markAsDirty();
                 return;
             }
@@ -575,6 +651,10 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
             }
         }
         if (toremove != null) {
+            ConnectorInfo info = channels[channel].getConnectors().get(toremove);
+            if (info != null) {
+                clearIfLogicOutput(toremove, info.getConnectorSettings());
+            }
             channels[channel].getConnectors().remove(toremove);
             markAsDirty();
         }
@@ -1095,6 +1175,12 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
 
     @Override
     public void onBlockBreak(World world, BlockPos pos, IBlockState state) {
+        for (int i = 0; i < MAX_CHANNELS; i++) {
+            if (channels[i] != null) {
+                clearChannelOutputs(i);
+            }
+        }
+
         super.onBlockBreak(world, pos, state);
         XNetBlobData blobData = XNetBlobData.getBlobData(this.world);
         WorldBlob worldBlob = blobData.getWorldBlob(this.world);


### PR DESCRIPTION
## Summary

This PR fixes several connector-related bugs:

- preserve logic output redstone level when copying/pasting connectors/channels
- fix copied connectors with color-based enabling staying active incorrectly
- clear stale redstone output when output mode/config/channel/controller is removed or changed
- make facaded connectors block light correctly

## Fixes

- Fixes #341
- Fixes #337
- Fixes #334

Related:
- ElaDiDu/XNet#2
- ElaDiDu/XNet#3

## Notes

The redstone-output fix is limited to explicit player/configuration changes to keep it low-overhead. In tests updating this output on topology-changes on the network, was laggy. Event that forces redstone output to 0, includes:
```
- changing a logic connector away from output mode (OUTPUT -> SENSOR)
- disabling a channel
- removing a connector (in gui)
- removing a channel (in gui)
- breaking the controller
```

The facade fix is scoped to light blocking only, without broader connector render/shape changes.