### PR TITLE
Longer timings, fluidchannel overhaul, JEI fill, Exclusion zone, name search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.8.19
 - Added 600 and 1200 timings to item/fluid/logic channels
 - Aligned Fluidchannel with itemchannel semantics
-  - Simple staggering to avoid silent failures when multiple simulations hit the same
+  - Simple staggering to avoid silent failures when multiple inserts hit the same
 fluidhandler on same tick.
 - Added JEI/HEI recipe fill support for item and fluid connector filters
     - Insert connectors add recipe inputs; extract connectors add recipe outputs
@@ -15,6 +15,8 @@ fluidhandler on same tick.
 - Prevented mouse-wheel count editing from accidentally clearing ghost filters
 - Disabled Mousetweak's WheelTweak for Controller. Repairs scrolling.
 - Search by connectornames in controllerGUI.
+- Config-entries: max limits for Normal/Advanced item and fluid connectors
+  - Print maxes on connector tooltip
 
 1.8.18:
 - Fixed Redstone Output Value not getting copy pasted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ fluidhandler on same tick. (itemhandlers does have this issue)
     - Shift + uses advanced/count-aware item fill
     - Fill is additive and preserves existing filters/settings
 - Added JEI and filter-control help buttons to the controller GUI
-- Improved JEI return behavior to keep the selected connector open
+- Improved JEI return behavior preserve
+  - last selected connector open
+  - search text field
 - Added proper GUI exclusionzone for JEI
 - Prevented mouse-wheel count editing from accidentally clearing ghost filters
 - Removed arbitrary controller RF input cap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ fluidhandler on same tick.
 - Added proper GUI exclusionzone for JEI
 - Prevented mouse-wheel count editing from accidentally clearing ghost filters
 - Disabled Mousetweak's WheelTweak for Controller. Repairs scrolling.
-
+- Search by connectornames in controllerGUI.
 
 1.8.18:
 - Fixed Redstone Output Value not getting copy pasted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 - Added 600 and 1200 timings to item/fluid/logic channels
 - Aligned Fluidchannel with itemchannel semantics
   - Simple staggering to avoid silent failures when multiple simulations hit the same
-fluidhandler on same tick. (itemhandlers does have this issue)
+fluidhandler on same tick.
 - Added JEI/HEI recipe fill support for item and fluid connector filters
     - Insert connectors add recipe inputs; extract connectors add recipe outputs
     - Shift + uses advanced/count-aware item fill
     - Fill is additive and preserves existing filters/settings
 - Added JEI and filter-control help buttons to the controller GUI
-- Improved JEI return behavior preserve
+- Improved JEI return behavior to preserve:
   - last selected connector open
   - search text field
 - Added proper GUI exclusionzone for JEI
 - Prevented mouse-wheel count editing from accidentally clearing ghost filters
-- Removed arbitrary controller RF input cap
+- Disabled Mousetweak's WheelTweak for Controller. Repairs scrolling.
 
 
 1.8.18:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+1.8.19
+- Added 600 and 1200 timings to item/fluid/logic channels
+- Aligned Fluidchannel with itemchannel semantics
+  - Simple staggering to avoid silent failures when multiple simulations hit the same
+fluidhandler on same tick. (itemhandlers does have this issue)
+- Added JEI/HEI recipe fill support for item and fluid connector filters
+    - Insert connectors add recipe inputs; extract connectors add recipe outputs
+    - Shift + uses advanced/count-aware item fill
+    - Fill is additive and preserves existing filters/settings
+- Added JEI and filter-control help buttons to the controller GUI
+- Improved JEI return behavior to keep the selected connector open
+- Added proper GUI exclusionzone for JEI
+- Prevented mouse-wheel count editing from accidentally clearing ghost filters
+- Removed arbitrary controller RF input cap
+
+
 1.8.18:
 - Fixed Redstone Output Value not getting copy pasted
 - Fixed copied connectors with color conditions behaving wrong until updated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -183,6 +183,8 @@ dependencies {
     implementation(rfg.deobf("curse.maven:redstoneflux-270789:2920436"))
     implementation(rfg.deobf("curse.maven:tesla-244651:2487959"))
     implementation("curse.maven:had-enough-items-557549:4810661")
+
+    compileOnly(rfg.deobf("curse.maven:mouse-tweaks-unofficial-461660:5876158"))
     // For ctm compat integration. (if ever)
     //implementation(rfg.deobf("curse.maven:ctm-267602:2915363"))
     implementation(rfg.deobf("curse.maven:the-one-probe-245211:2667280"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 // Project properties
 group = "eladidu.xnet"
-version = "1.8.18"
+version = "1.8.19"
 
 // Set the toolchain version to decouple the Java we run Gradle with from the Java used to compile and run the mod
 java {

--- a/src/main/java/mcjty/xnet/XNet.java
+++ b/src/main/java/mcjty/xnet/XNet.java
@@ -31,7 +31,7 @@ public class XNet implements ModBase {
 
     public static final String MODID = "xnet";
     public static final String MODNAME = "XNet";
-    public static final String MODVERSION = "1.8.18";
+    public static final String MODVERSION = "1.8.19";
 
     public static final String MIN_FORGE11_VER = "13.19.0.2176";
     public static final String MIN_MCJTYLIB_VER = "3.5.0";

--- a/src/main/java/mcjty/xnet/api/helper/AbstractConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/api/helper/AbstractConnectorSettings.java
@@ -105,9 +105,13 @@ public abstract class AbstractConnectorSettings implements IConnectorSettings {
     }
 
     @Override
-    public void sanitizeSettings(boolean advanced)
-    {
+    public void sanitizeSettings(boolean advanced) {
+        this.advanced = advanced;
         facingOverride = advanced ? facingOverride : null;
+    }
+
+    public boolean isAdvanced() {
+        return advanced;
     }
 
     protected static <T extends Enum<T>> void setEnumSafe(JsonObject object, String tag, T value) {

--- a/src/main/java/mcjty/xnet/apiimpl/EnumStringTranslators.java
+++ b/src/main/java/mcjty/xnet/apiimpl/EnumStringTranslators.java
@@ -24,6 +24,7 @@ public class EnumStringTranslators {
     private static Map<String, ItemChannelSettings.ChannelMode> itemChannelModeMap;
     private static Map<String, FluidChannelSettings.ChannelMode> fluidChannelModeMap;
     private static Map<String, FluidConnectorSettings.FluidMode> fluidModeMap;
+    private static Map<String, FluidConnectorSettings.AmountMode> fluidAmountModeMap;
     private static Map<String, EnergyConnectorSettings.EnergyMode> energyModeMap;
     private static Map<String, LogicConnectorSettings.LogicMode> logicModeMap;
     private static Map<String, Sensor.SensorMode> sensorModeMap;
@@ -83,6 +84,17 @@ public class EnumStringTranslators {
             }
         }
         return fluidModeMap.get(mode);
+    }
+
+    @Nullable
+    public static FluidConnectorSettings.AmountMode getFluidAmountMode(String mode) {
+        if (fluidAmountModeMap == null) {
+            fluidAmountModeMap = new HashMap<>();
+            for (FluidConnectorSettings.AmountMode value : FluidConnectorSettings.AmountMode.values()) {
+                fluidAmountModeMap.put(value.name(), value);
+            }
+        }
+        return fluidAmountModeMap.get(mode);
     }
 
     @Nullable

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
@@ -59,6 +59,20 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         return channelMode;
     }
 
+    private static int capFluidTransfer(FluidConnectorSettings connector, int amount) {
+        // Fast path: both normal and advanced caps are default/ unlimited,
+        // so nothing to clamp and no need to check connector-type.
+        if (!ConfigSetup.fluidTransferCapsEnabled) {
+            return amount;
+        }
+
+        int maxTransfer = connector.isAdvanced()
+                ? ConfigSetup.maxFluidTransferAdvancedCached
+                : ConfigSetup.maxFluidTransferNormalCached;
+
+        return amount > maxTransfer ? maxTransfer : amount;
+    }
+
     @Override
     public JsonObject writeToJson()
     {
@@ -286,26 +300,28 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         return startIdx;
     }
 
-    private static int getExtractAmount(FluidConnectorSettings connector)
-    {
+    private static int getExtractAmount(FluidConnectorSettings connector) {
+        int amount;
         switch (connector.getAmountMode()) {
             case BUCKET:
-                return 1000;
-            case BUCK8:
-                return 8000;
+                amount = 1000;
+                break;
             case HIGHEST:
-                return Integer.MAX_VALUE;
+                amount = Integer.MAX_VALUE;
+                break;
             case RATE:
             default:
                 Integer rate = connector.getRate();
-                return rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
+                amount = rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
+                break;
         }
+        return capFluidTransfer(connector, amount);
     }
 
-    private static int getInsertRate(FluidConnectorSettings connector)
-    {
+    private static int getInsertRate(FluidConnectorSettings connector) {
         Integer rate = connector.getRate();
-        return rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
+        int amount = rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
+        return capFluidTransfer(connector, amount);
     }
 
 

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
@@ -13,8 +13,6 @@ import mcjty.xnet.api.helper.DefaultChannelSettings;
 import mcjty.xnet.api.keys.ConsumerId;
 import mcjty.xnet.apiimpl.EnumStringTranslators;
 import mcjty.xnet.api.keys.SidedConsumer;
-import mcjty.xnet.apiimpl.MInteger;
-import mcjty.xnet.blocks.cables.ConnectorBlock;
 import mcjty.xnet.config.ConfigSetup;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -112,7 +110,7 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         delay--;
         if (delay <= 0)
         {
-            delay = 200 * 6;      // Multiply of the different speeds we have
+            delay = 200 * 6;      // Multiple of the different speeds we have
         }
         if (delay % 10 != 0)
         {
@@ -121,17 +119,18 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         int d = delay / 10;
 
         updateCache(channel, context);
-        // @todo optimize
         World world = context.getControllerWorld();
         for (Map.Entry<SidedConsumer, FluidConnectorSettings> entry : fluidExtractors.entrySet())
         {
             FluidConnectorSettings settings = entry.getValue();
-            if (d % settings.getSpeed() != 0)
-            {
+            ConsumerId consumerId = entry.getKey().getConsumerId();
+
+            int speed = settings.getSpeed();
+            int phase = consumerId.getId() % speed;
+            if (d % speed != phase) {
                 continue;
             }
 
-            ConsumerId consumerId = entry.getKey().getConsumerId();
             BlockPos extractorPos = context.findConsumerPosition(consumerId);
             if (extractorPos != null)
             {
@@ -151,9 +150,10 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
 
                 int idx = getStartExtractIndex(settings, consumerId, handler);
                 idx = tickFluidHandler(context, settings, extractorPos, handler, idx);
-                if (handler.getTankProperties().length > 0)
+                if (settings.getExtractMode() != FluidConnectorSettings.ExtractMode.SLOT
+                        && handler.getTankProperties().length > 0) {
                     rememberExtractIndex(consumerId, (idx + 1) % handler.getTankProperties().length);
-
+                }
             }
         }
     }
@@ -172,7 +172,6 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                 if (slotCount == 0)
                     return 0;
 
-                // Try 5 times to find a non empty slot
                 for (int i = 0; i < 5; i++)
                 {
                     int idx = random.nextInt(slotCount);
@@ -181,7 +180,6 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                         return idx;
                     }
                 }
-                // Otherwise use a more complicated algorithm
                 List<Integer> slots = new ArrayList<>();
                 for (int i = 0; i < slotCount; i++)
                 {
@@ -198,6 +196,11 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
             }
             case ORDER:
                 return getExtractIndex(consumerId);
+            case SLOT:
+            {
+                Integer tank = settings.getExtractTank();
+                return tank == null ? 0 : tank;
+            }
         }
         return 0;
     }
@@ -225,16 +228,40 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
 
         if (context.checkAndConsumeRF(ConfigSetup.controllerOperationRFT.get()))
         {
-            int rate = getRate(settings, context.getControllerWorld(), extractorPos);
+            int extractAmount = getExtractAmount(settings);
             int slots = handler.getTankProperties().length;
+
+            if (settings.getExtractMode() == FluidConnectorSettings.ExtractMode.SLOT) {
+                if (startIdx < 0 || startIdx >= slots) {
+                    return startIdx;
+                }
+                FluidStack stack = fetchFluid(handler, true, extractMatcher, extractAmount, startIdx);
+                if (stack != null) {
+                    int toextract = stack.amount;
+                    if (count != null) {
+                        int canextract = amount - count;
+                        if (canextract <= 0) {
+                            return startIdx;
+                        }
+                        if (canextract < toextract) {
+                            stack = stack.copy();
+                            stack.amount = canextract;
+                        }
+                    }
+
+                    if (transferStack(handler, stack, settings, startIdx, context)) {
+                        return startIdx;
+                    }
+                }
+                return startIdx;
+            }
+
             for (int i = startIdx; i < startIdx + slots; i++)
             {
                 int idx = i % slots;
-                FluidStack stack = fetchFluid(handler, true, extractMatcher, rate, idx);
+                FluidStack stack = fetchFluid(handler, true, extractMatcher, extractAmount, idx);
                 if (stack != null)
                 {
-                    // Now that we have a stack we first reduce the amount of the stack if we want to keep a certain
-                    // number of items
                     int toextract = stack.amount;
                     if (count != null)
                     {
@@ -245,9 +272,8 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                         }
                         if (canextract < toextract)
                         {
-                            toextract = canextract;
                             stack = stack.copy();
-                            stack.amount = toextract;
+                            stack.amount = canextract;
                         }
                     }
 
@@ -260,13 +286,26 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         return startIdx;
     }
 
-    private static int getRate(FluidConnectorSettings connector, World world, BlockPos pos)
+    private static int getExtractAmount(FluidConnectorSettings connector)
+    {
+        switch (connector.getAmountMode()) {
+            case BUCKET:
+                return 1000;
+            case BUCK8:
+                return 8000;
+            case HIGHEST:
+                return Integer.MAX_VALUE;
+            case RATE:
+            default:
+                Integer rate = connector.getRate();
+                return rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
+        }
+    }
+
+    private static int getInsertRate(FluidConnectorSettings connector)
     {
         Integer rate = connector.getRate();
-        if (rate != null)
-            return Math.max(0, rate);
-
-        return ConnectorBlock.isAdvancedConnector(world, pos) ? ConfigSetup.maxFluidRateAdvanced.get() : ConfigSetup.maxFluidRateNormal.get();
+        return rate == null ? Integer.MAX_VALUE : Math.max(0, rate);
     }
 
 
@@ -307,11 +346,19 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                                  FluidConnectorSettings extractSettings, int extractIdx,
                                  @Nonnull IControllerContext context)
     {
+        if (fluidConsumers == null || fluidConsumers.isEmpty()) {
+            return false;
+        }
+
         if (channelMode == ChannelMode.DISTRIBUTE)
         {
             Map<Pair<SidedConsumer, FluidConnectorSettings>, Integer> distribution = new HashMap<>();
-            int overallFilled = getOverallAndDistribution(distribution, context, stack);
-            int extracted = fillDistribute(distribution, overallFilled, context, stack);
+            int planned = getOverallAndDistribution(distribution, context, stack);
+            if (planned <= 0) {
+                return false;
+            }
+
+            int extracted = fillDistribute(distribution, context, stack);
             if (extracted > 0)
             {
                 // Insert then extract, should still be consistent?
@@ -319,8 +366,9 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                         extractSettings.getMatcher(),
                         extracted,
                         extractIdx);
-                if (realInsert.amount != extracted)
-                    throw new RuntimeException("Expected to extract " + extracted + " fluid but extracted " + realInsert.amount);
+                if (realInsert == null || realInsert.amount != extracted) {
+                    throw new RuntimeException("Expected to extract " + extracted + " fluid but extracted " + (realInsert == null ? "null" : realInsert.amount));
+                }
                 return true;
             }
             return false;
@@ -360,7 +408,7 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                 continue;
 
 
-            int remaining = insertToHandler(from, handler, stack, extractSettings, insertSettings, extractIdx, world, consumerPos);
+            int remaining = insertToHandler(from, handler, stack, extractSettings, insertSettings, extractIdx);
             // Round robin inserts to 1 inventory only
             if (channelMode == ChannelMode.ROUNDROBIN && originalCount != remaining)
                 return true;
@@ -377,12 +425,15 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
      */
     public int insertToHandler(@Nonnull IFluidHandler from, @Nonnull IFluidHandler to, @Nonnull FluidStack stack,
                                FluidConnectorSettings extractSettings, FluidConnectorSettings insertSettings,
-                               int extractIdx, World world, BlockPos consumerPos)
+                               int extractIdx)
     {
         Integer count = insertSettings.getMinmax();
         int total = stack.amount;
-        int rate = getRate(insertSettings, world, consumerPos);
+        int rate = getInsertRate(insertSettings);
         int toInsert = Math.min(rate, total);
+        if (toInsert <= 0) {
+            return total;
+        }
         if (count != null)
         {
             int amount = countFluid(to, insertSettings.getMatcher());
@@ -406,13 +457,16 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                     extractSettings.getMatcher(),
                     filled,
                     extractIdx);
+            if (realInsert == null || realInsert.amount != filled) {
+                throw new RuntimeException("Expected to extract " + filled + " fluid but extracted " + (realInsert == null ? "null" : realInsert.amount));
+            }
             // Insert for real
             to.fill(realInsert, true);
 
             return total - filled;
         }
 
-        return stackToInsert.amount;
+        return total;
     }
 
 
@@ -451,8 +505,10 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                     continue;
 
                 Integer count = settings.getMinmax();
-                int rate = getRate(settings, world, consumerPos);
+                int rate = getInsertRate(settings);
                 int toInsert = Math.min(rate, total);
+                if (toInsert <= 0)
+                    continue;
                 if (count != null)
                 {
                     int amount = countFluid(handler, settings.getMatcher());
@@ -471,7 +527,9 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
                 fillPossible.put(entry, possible);
             }
         }
-
+        if (filledOverall <= 0) {
+            return 0;
+        }
         int amountExtracted = 0;
         for (Map.Entry<Pair<SidedConsumer, FluidConnectorSettings>, Integer> entry : fillPossible.entrySet())
         {
@@ -499,7 +557,7 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
 
         return amountExtracted;
     }
-    private int fillDistribute(Map<Pair<SidedConsumer, FluidConnectorSettings>, Integer> fillPer, int filledOverall,
+    private int fillDistribute(Map<Pair<SidedConsumer, FluidConnectorSettings>, Integer> fillPer,
                                @Nonnull IControllerContext context, @Nonnull FluidStack stack)
     {
         World world = context.getControllerWorld();
@@ -515,8 +573,10 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
             IFluidHandler handler = getFluidHandlerAt(te, settings.getFacing());
 
             Integer count = settings.getMinmax();
-            int rate = getRate(settings, world, consumerPos);
+            int rate = getInsertRate(settings);
             int toInsert = Math.min(rate, stack.amount);
+            if (toInsert <= 0)
+                continue;
             if (count != null)
             {
                 int amount = countFluid(handler, settings.getMatcher());

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
@@ -13,7 +13,6 @@ import mcjty.xnet.api.gui.IEditorGui;
 import mcjty.xnet.api.gui.IndicatorIcon;
 import mcjty.xnet.api.helper.AbstractConnectorSettings;
 import mcjty.xnet.apiimpl.EnumStringTranslators;
-import mcjty.xnet.config.ConfigSetup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -35,12 +34,15 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     public static final String TAG_MINMAX = "minmax";
     public static final String TAG_PRIORITY = "priority";
     public static final String TAG_FILTER = "flt";
+    public static final String TAG_BLACKLIST = "blacklist";
+    public static final String TAG_AMOUNTMODE = "amountmode";
     public static final String TAG_SPEED = "speed";
     public static final String TAG_EXTRACT = "extract";
+    public static final String TAG_TANK = "tank";
 
     public static final int FILTER_SIZE = 18;
     public static final IntList SPEEDS = new IntArrayList(new int[]{2, 6, 10, 20});
-    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 6, 10, 20});
+    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 6, 10, 20, 60, 120});
 
     public enum FluidMode {
         INS,
@@ -51,7 +53,16 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     {
         FIRST,
         RND,
-        ORDER
+        ORDER,
+        SLOT
+    }
+
+    public enum AmountMode
+    {
+        BUCKET,
+        BUCK8,
+        RATE,
+        HIGHEST
     }
 
     private FluidMode fluidMode = FluidMode.INS;
@@ -60,6 +71,9 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     @Nullable private Integer minmax = null;
     private int speed = 2;
     private ExtractMode extractMode = ExtractMode.FIRST;
+    private AmountMode amountMode = AmountMode.BUCKET;
+    @Nullable private Integer extractTank = null;
+    private boolean blacklist = false;
 
     private ItemStackList filters = ItemStackList.create(FILTER_SIZE);
 
@@ -96,10 +110,16 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     {
         return extractMode;
     }
-
+    public AmountMode getAmountMode() {return amountMode; }
+    @Nullable
+    public Integer getExtractTank() {return extractTank; }
     public ItemStackList getFilters()
     {
         return filters;
+    }
+
+    public boolean isBlacklist() {
+        return blacklist;
     }
 
     @Nullable
@@ -124,55 +144,94 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     public void createGui(IEditorGui gui) {
         advanced = gui.isAdvanced();
         String[] speeds;
-        int maxrate;
         if (advanced) {
-            speeds = new String[] { "10", "20", "60", "100", "200" };
-            maxrate = ConfigSetup.maxFluidRateAdvanced.get();
+            speeds = new String[] { "10", "20", "60", "100", "200", "600", "1200" };
         } else {
             speeds = new String[] { "20", "60", "100", "200" };
-            maxrate = ConfigSetup.maxFluidRateNormal.get();
         }
 
         sideGui(gui);
         colorsGui(gui);
         redstoneGui(gui);
-        gui.nl()
-                .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
-                .choices(TAG_SPEED, "Number of ticks for each operation", Integer.toString(speed * 10), speeds)
-                .nl()
 
-                .label("Pri").integer(TAG_PRIORITY, "Insertion priority", priority, 36)
-                .shift(5)
-                .choices(TAG_EXTRACT, "Extract mode (first available,|random slot or round robin)", extractMode, ExtractMode.values())
-                .nl()
+        if (fluidMode == FluidMode.EXT) {
+            gui.nl()
+                    .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
+                    .choices(TAG_AMOUNTMODE, "Extraction amount |Bucket, Buck8, Rate, Highest", amountMode, AmountMode.values());
 
-                .label("Rate")
-                .integer(TAG_RATE, fluidMode == FluidMode.EXT ? "Fluid extraction rate|(max " + maxrate + "mb)" : "Fluid insertion rate|(max " + maxrate + "mb)", rate, 36, maxrate)
-                .shift(10)
-                .label(fluidMode == FluidMode.EXT ? "Min" : "Max")
-                .integer(TAG_MINMAX, fluidMode == FluidMode.EXT ? "Keep this amount of|fluid in tank" : "Disable insertion if|fluid level is too high", minmax, 36)
-                .nl();
+            if (amountMode == AmountMode.RATE) {
+                gui.integer(TAG_RATE, "Fluid extraction rate|per operation|(empty = unlimited)", rate, 36);
+            }
+
+            gui.shift(2)
+                    .choices(TAG_SPEED, "Number of ticks for each operation", Integer.toString(speed * 10), speeds)
+                    .nl()
+
+                    .label("Pri").integer(TAG_PRIORITY, "Insertion priority", priority, 36)
+                    .shift(5)
+                    .choices(TAG_EXTRACT, "Extract mode (first available,|random slot, round robin or slot)", extractMode, ExtractMode.values());
+
+            if (extractMode == ExtractMode.SLOT) {
+                gui.shift(5)
+                        .integer(TAG_TANK, "Tank to extract from|(blank = 0)", extractTank, 30);
+            }
+
+            gui.nl()
+
+                    .toggleText(TAG_BLACKLIST, "Enable blacklist mode", "BL", blacklist).shift(2)
+                    .shift(20)
+                    .label("Min")
+                    .integer(TAG_MINMAX, "Keep this amount of|fluid in tank", minmax, 36)
+                    .nl();
+        } else {
+            gui.nl()
+                    .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
+                    .integer(TAG_RATE, "Fluid insertion rate|per operation|(empty = unlimited)", rate, 36)
+                    .choices(TAG_SPEED, "Number of ticks for each operation", Integer.toString(speed * 10), speeds)
+                    .nl()
+
+                    .label("Pri").integer(TAG_PRIORITY, "Insertion priority", priority, 36)
+                    .nl()
+
+                    .toggleText(TAG_BLACKLIST, "Enable blacklist mode", "BL", blacklist).shift(2)
+                    .shift(20)
+                    .label("Max")
+                    .integer(TAG_MINMAX, "Disable insertion if|fluid level is too high", minmax, 36)
+                    .nl();
+        }
+
         for (int i = 0 ; i < FILTER_SIZE; i++) {
             gui.ghostSlot(TAG_FILTER + i, filters.get(i));
         }
     }
 
-    private static Set<String> INSERT_TAGS = ImmutableSet.of(TAG_MODE, TAG_RS, TAG_COLOR+"0", TAG_COLOR+"1", TAG_COLOR+"2", TAG_COLOR+"3", TAG_RATE, TAG_MINMAX, TAG_PRIORITY);
-    private static Set<String> EXTRACT_TAGS = ImmutableSet.of(TAG_MODE, TAG_RS, TAG_COLOR+"0", TAG_COLOR+"1", TAG_COLOR+"2", TAG_COLOR+"3", TAG_RATE, TAG_MINMAX, TAG_PRIORITY, TAG_SPEED, TAG_EXTRACT);
+    private static Set<String> INSERT_TAGS = ImmutableSet.of(
+            TAG_MODE, TAG_RS,
+            TAG_COLOR+"0", TAG_COLOR+"1", TAG_COLOR+"2", TAG_COLOR+"3",
+            TAG_RATE, TAG_MINMAX, TAG_PRIORITY, TAG_BLACKLIST
+    );
+    private static final Set<String> EXTRACT_TAGS = ImmutableSet.of(
+            TAG_MODE, TAG_RS,
+            TAG_COLOR+"0", TAG_COLOR+"1", TAG_COLOR+"2", TAG_COLOR+"3",
+            TAG_RATE, TAG_MINMAX, TAG_PRIORITY, TAG_SPEED, TAG_EXTRACT, TAG_BLACKLIST, TAG_AMOUNTMODE, TAG_TANK
+    );
 
     @Override
     public boolean isEnabled(String tag) {
         if (tag.startsWith(TAG_FILTER)) {
             return true;
         }
+        if (tag.equals(TAG_FACING)) {
+            return advanced;
+        }
         if (fluidMode == FluidMode.INS) {
-            if (tag.equals(TAG_FACING)) {
-                return advanced;
-            }
             return INSERT_TAGS.contains(tag);
         } else {
-            if (tag.equals(TAG_FACING)) {
-                return advanced;
+            if (tag.equals(TAG_RATE)) {
+                return amountMode == AmountMode.RATE;
+            }
+            if (tag.equals(TAG_TANK)) {
+                return extractMode == ExtractMode.SLOT;
             }
             return EXTRACT_TAGS.contains(tag);
         }
@@ -199,10 +258,13 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
             {
                 matcher = fluidStack ->
                 {
+                    boolean match = false;
                     for (ItemStack filterStack : filterList)
-                        if (fluidStack.equals(FluidTools.convertBucketToFluid(filterStack)))
-                            return true;
-                    return false;
+                        if (fluidStack.equals(FluidTools.convertBucketToFluid(filterStack))) {
+                            match = true;
+                            break;
+                        }
+                    return blacklist ? !match : match;
                 };
             }
 
@@ -218,17 +280,37 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     @Override
     public void update(Map<String, Object> data) {
         super.update(data);
-        fluidMode = FluidMode.valueOf(((String)data.get(TAG_MODE)).toUpperCase());
-        rate = (Integer) data.get(TAG_RATE);
+        fluidMode = FluidMode.valueOf(((String) data.get(TAG_MODE)).toUpperCase());
+
+        Object amountModeObj = data.get(TAG_AMOUNTMODE);
+        if (amountModeObj != null) {
+            amountMode = AmountMode.valueOf(((String) amountModeObj).toUpperCase());
+        }
+
+        if (data.containsKey(TAG_RATE)) {
+            rate = (Integer) data.get(TAG_RATE);
+        }
+
         minmax = (Integer) data.get(TAG_MINMAX);
         priority = (Integer) data.get(TAG_PRIORITY);
+        blacklist = Boolean.TRUE.equals(data.get(TAG_BLACKLIST));
+
         speed = Integer.parseInt((String) data.get(TAG_SPEED)) / 10;
         if (speed == 0) {
             speed = 2;
         }
-        extractMode = ExtractMode.valueOf(((String)data.get(TAG_EXTRACT)).toUpperCase());
-        for (int i = 0; i < FILTER_SIZE; i++)
-        {
+
+        Object extractModeObj = data.get(TAG_EXTRACT);
+        if (extractModeObj != null) {
+            extractMode = ExtractMode.valueOf(((String) extractModeObj).toUpperCase());
+        }
+        if (data.containsKey(TAG_TANK)) {
+            extractTank = (Integer) data.get(TAG_TANK);
+        }
+        if (extractTank != null && extractTank < 0) {
+            extractTank = null;
+        }
+        for (int i = 0; i < FILTER_SIZE; i++) {
             filters.set(i, (ItemStack) data.get(TAG_FILTER + i));
         }
         matcher = null;
@@ -247,19 +329,19 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         JsonObject object = new JsonObject();
         super.writeToJsonInternal(object);
         setEnumSafe(object, "fluidmode", fluidMode);
+        setEnumSafe(object, "amountmode", amountMode);
         setIntegerSafe(object, "priority", priority);
         setIntegerSafe(object, "rate", rate);
         setIntegerSafe(object, "minmax", minmax);
         setIntegerSafe(object, "speed", speed);
+        setIntegerSafe(object, "tank", extractTank);
+        object.add("blacklist", new JsonPrimitive(blacklist));
         for (int i = 0; i < FILTER_SIZE; i++)
         {
             if (!filters.get(i).isEmpty())
             {
                 object.add("filter" + i, ItemStackTools.itemStackToJson(filters.get(i)));
             }
-        }
-        if (rate != null && rate > ConfigSetup.maxFluidRateNormal.get()) {
-            object.add("advancedneeded", new JsonPrimitive(true));
         }
         if (speed == 1) {
             object.add("advancedneeded", new JsonPrimitive(true));
@@ -272,10 +354,16 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     public void readFromJson(JsonObject object) {
         super.readFromJsonInternal(object);
         fluidMode = getEnumSafe(object, "fluidmode", EnumStringTranslators::getFluidMode);
+        amountMode = object.has("amountmode") ? getEnumSafe(object, "amountmode", EnumStringTranslators::getFluidAmountMode) : AmountMode.BUCKET;
         priority = getIntegerSafe(object, "priority");
         rate = getIntegerSafe(object, "rate");
         minmax = getIntegerSafe(object, "minmax");
         speed = getIntegerNotNull(object, "speed");
+        extractTank = getIntegerSafe(object, "tank");
+        if (extractTank != null && extractTank < 0) {
+            extractTank = null;
+        }
+        blacklist = getBoolSafe(object, "blacklist");
         for (int i = 0 ; i < FILTER_SIZE ; i++)
         {
             if (object.has("filter" + i))
@@ -296,6 +384,11 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     {
         super.readFromNBT(tag);
         fluidMode = FluidMode.values()[tag.getByte("fluidMode")];
+        if (tag.hasKey("amountMode")) {
+            amountMode = AmountMode.values()[tag.getByte("amountMode")];
+        } else {
+            amountMode = AmountMode.BUCKET;
+        }
         if (tag.hasKey("priority"))
         {
             priority = tag.getInteger("priority");
@@ -303,6 +396,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         {
             priority = null;
         }
+        blacklist = tag.getBoolean("blacklist");
         if (tag.hasKey("rate"))
         {
             rate = tag.getInteger("rate");
@@ -321,6 +415,14 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         if (speed == 0)
         {
             speed = 2;
+        }
+        if (tag.hasKey("tank")) {
+            extractTank = tag.getInteger("tank");
+            if (extractTank < 0) {
+                extractTank = null;
+            }
+        } else {
+            extractTank = null;
         }
         // Old 1 item filter check for compat
         if (tag.hasKey("filter"))
@@ -354,12 +456,15 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
                 extractMode = ExtractMode.FIRST;
             }
         }
+        matcher = null;
     }
 
     @Override
     public void writeToNBT(NBTTagCompound tag) {
         super.writeToNBT(tag);
         tag.setByte("fluidMode", (byte) fluidMode.ordinal());
+        tag.setByte("amountMode", (byte) amountMode.ordinal());
+        tag.setBoolean("blacklist", blacklist);
         if (priority != null) {
             tag.setInteger("priority", priority);
         }
@@ -378,5 +483,8 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
             }
         }
         tag.setByte("extractMode", (byte) extractMode.ordinal());
+        if (extractTank != null) {
+            tag.setInteger("tank", extractTank);
+        }
     }
 }

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
@@ -60,7 +60,6 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     public enum AmountMode
     {
         BUCKET,
-        BUCK8,
         RATE,
         HIGHEST
     }
@@ -140,9 +139,36 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         return null;
     }
 
+    // if someone tried the dirty jar on their save, help them
+    private static AmountMode readAmountModeFromNBT(NBTTagCompound tag) {
+        if (!tag.hasKey("amountMode")) {
+            return AmountMode.BUCKET;
+        }
+
+        int rawMode = tag.getByte("amountMode") & 255;
+        AmountMode[] values = AmountMode.values();
+
+        if (rawMode < values.length) {
+            return values[rawMode];
+        }
+        // Crash-safety for old dev-alpha saves where HIGHEST was ordinal 3.
+        if (rawMode == 3) {
+            return AmountMode.HIGHEST;
+        }
+
+        return AmountMode.BUCKET;
+    }
+
+    private void sanitizeFluidTransferSettings() {
+        if (amountMode == null) {
+            amountMode = AmountMode.BUCKET;
+        }
+    }
+
     @Override
     public void createGui(IEditorGui gui) {
         advanced = gui.isAdvanced();
+        sanitizeFluidTransferSettings();
         String[] speeds;
         if (advanced) {
             speeds = new String[] { "10", "20", "60", "100", "200", "600", "1200" };
@@ -157,10 +183,10 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         if (fluidMode == FluidMode.EXT) {
             gui.nl()
                     .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
-                    .choices(TAG_AMOUNTMODE, "Extraction amount |Bucket, Buck8, Rate, Highest", amountMode, AmountMode.values());
+                    .choices(TAG_AMOUNTMODE, "Extraction amount|Bucket, Rate, Highest", amountMode, AmountMode.values());
 
             if (amountMode == AmountMode.RATE) {
-                gui.integer(TAG_RATE, "Fluid extraction rate|per operation|(empty = unlimited)", rate, 36);
+                gui.integer(TAG_RATE, "Fluid extraction rate|per operation|(empty = max)", rate, 36);
             }
 
             gui.shift(2)
@@ -186,7 +212,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         } else {
             gui.nl()
                     .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
-                    .integer(TAG_RATE, "Fluid insertion rate|per operation|(empty = unlimited)", rate, 36)
+                    .integer(TAG_RATE, "Fluid insertion rate|per operation|(empty = max)", rate, 36)
                     .choices(TAG_SPEED, "Number of ticks for each operation", Integer.toString(speed * 10), speeds)
                     .nl()
 
@@ -290,7 +316,6 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         if (data.containsKey(TAG_RATE)) {
             rate = (Integer) data.get(TAG_RATE);
         }
-
         minmax = (Integer) data.get(TAG_MINMAX);
         priority = (Integer) data.get(TAG_PRIORITY);
         blacklist = Boolean.TRUE.equals(data.get(TAG_BLACKLIST));
@@ -313,6 +338,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         for (int i = 0; i < FILTER_SIZE; i++) {
             filters.set(i, (ItemStack) data.get(TAG_FILTER + i));
         }
+        sanitizeFluidTransferSettings();
         matcher = null;
     }
 
@@ -322,6 +348,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
         super.sanitizeSettings(advanced);
         int minSpeed = advanced ? ADVANCED_SPEEDS.get(0) : SPEEDS.get(0);
         speed = Math.max(speed, minSpeed);
+        sanitizeFluidTransferSettings();
     }
 
     @Override
@@ -375,6 +402,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
             }
         }
         extractMode = getEnumSafe(object, "extractmode", EnumStringTranslators::getFluidExtractMode);
+        sanitizeFluidTransferSettings();
         matcher = null;
     }
 
@@ -384,11 +412,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
     {
         super.readFromNBT(tag);
         fluidMode = FluidMode.values()[tag.getByte("fluidMode")];
-        if (tag.hasKey("amountMode")) {
-            amountMode = AmountMode.values()[tag.getByte("amountMode")];
-        } else {
-            amountMode = AmountMode.BUCKET;
-        }
+        amountMode = readAmountModeFromNBT(tag);
         if (tag.hasKey("priority"))
         {
             priority = tag.getInteger("priority");
@@ -456,6 +480,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
                 extractMode = ExtractMode.FIRST;
             }
         }
+        sanitizeFluidTransferSettings();
         matcher = null;
     }
 

--- a/src/main/java/mcjty/xnet/apiimpl/items/ItemChannelSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/items/ItemChannelSettings.java
@@ -68,6 +68,20 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
         return 0;
     }
 
+    private static int capItemTransfer(ItemConnectorSettings connector, int amount) {
+        // Fast path: both normal and advanced caps are default/ unlimited,
+        // so nothing to clamp and no need to check connector-type.
+        if (!ConfigSetup.itemTransferCapsEnabled) {
+            return amount;
+        }
+
+        int maxTransfer = connector.isAdvanced()
+                ? ConfigSetup.maxItemTransferAdvancedCached
+                : ConfigSetup.maxItemTransferNormalCached;
+
+        return amount > maxTransfer ? maxTransfer : amount;
+    }
+
     @Override
     public JsonObject writeToJson() {
         JsonObject object = new JsonObject();
@@ -264,7 +278,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
                 extractMatcher,
                 settings.getStackMode(),
                 settings.getExtractAmount(),
-                Integer.MAX_VALUE,
+                capItemTransfer(settings, ConfigSetup.MAX_TRANSFER_UNLIMITED),
                 idx);
         if (stack.isEmpty())
             return ItemStack.EMPTY;
@@ -374,7 +388,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
         Integer count = insertSettings.getCount();
         int slots = to.getSlots();
         int total = stack.getCount();
-        int toInsert = total;
+        int toInsert = capItemTransfer(insertSettings, total);
         if (count != null)
         {
             int amount = countItems(to, insertSettings.getMatcher());
@@ -444,7 +458,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
     {
         Integer count = insertSettings.getCount();
         int total = stack.getCount();
-        int toInsert = total;
+        int toInsert = capItemTransfer(insertSettings, total);
         if (count != null)
         {
             int amount = RFToolsSupport.countItems(to, insertSettings.getMatcher(), count);
@@ -509,7 +523,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
                     BlockPos pos = consumerPos.offset(side);
                     TileEntity te = world.getTileEntity(pos);
                     int actuallyinserted = 0;
-                    int toinsert = total;
+                    int toinsert = capItemTransfer(settings, total);
                     ItemStack remaining;
                     Integer count = settings.getCount();
 
@@ -576,7 +590,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
             BlockPos pos = consumerPosition.offset(side);
             TileEntity te = context.getControllerWorld().getTileEntity(pos);
             if (ModSetup.rftools && RFToolsSupport.isStorageScanner(te)) {
-                int toinsert = total;
+                int toinsert = capItemTransfer(settings, total);
                 Integer count = settings.getCount();
                 if (count != null) {
                     int amount = RFToolsSupport.countItems(te, settings.getMatcher(), count);
@@ -607,7 +621,7 @@ public class ItemChannelSettings extends DefaultChannelSettings implements IChan
             } else {
                 IItemHandler handler = getItemHandlerAt(te, settings.getFacing());
 
-                int toinsert = total;
+                int toinsert = capItemTransfer(settings, total);
                 Integer count = settings.getCount();
                 if (count != null) {
                     int amount = countItems(handler, settings.getMatcher());

--- a/src/main/java/mcjty/xnet/apiimpl/items/ItemConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/items/ItemConnectorSettings.java
@@ -45,7 +45,7 @@ public class ItemConnectorSettings extends AbstractConnectorSettings {
 
     public static final int FILTER_SIZE = 18;
     public static final IntList SPEEDS = new IntArrayList(new int[]{2, 4, 12, 20, 40});
-    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 4, 12, 20, 40});
+    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 4, 12, 20, 40, 120, 240});
 
     public enum ItemMode {
         INS,
@@ -117,7 +117,7 @@ public class ItemConnectorSettings extends AbstractConnectorSettings {
         advanced = gui.isAdvanced();
         String[] speeds;
         if (advanced) {
-            speeds = new String[] { "5", "10", "20", "60", "100", "200" };
+            speeds = new String[] { "5", "10", "20", "60", "100", "200", "600", "1200"};
         } else {
             speeds = new String[] { "10", "20", "60", "100", "200" };
         }
@@ -127,7 +127,6 @@ public class ItemConnectorSettings extends AbstractConnectorSettings {
         redstoneGui(gui);
         gui.nl()
                 .choices(TAG_MODE, "Insert or extract mode", itemMode, ItemMode.values())
-                .shift(5)
                 .choices(TAG_STACK, "Single item, stack, count max, highest, count exact (up to destination's space)", stackMode, StackMode.values());
 
         if ((stackMode == StackMode.COUNTM || stackMode == StackMode.COUNTE) && itemMode == ItemMode.EXT) {
@@ -261,6 +260,15 @@ public class ItemConnectorSettings extends AbstractConnectorSettings {
     {
         return countMode;
     }
+
+    public boolean isOredictMode() { return oredictMode; }
+
+    public boolean isMetaMode() { return metaMode; }
+
+    public boolean isNbtMode() { return nbtMode; }
+
+    @Nullable
+    public Integer getExtractAmountSetting() { return extractAmount; }
 
     public ItemStackList getFilters()
     {

--- a/src/main/java/mcjty/xnet/apiimpl/logic/LogicChannelSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/logic/LogicChannelSettings.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/mcjty/xnet/apiimpl/logic/LogicConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/logic/LogicConnectorSettings.java
@@ -40,7 +40,7 @@ public class LogicConnectorSettings extends AbstractConnectorSettings {
 
     public static final int SENSORS = 4;
     public static final IntList SPEEDS = new IntArrayList(new int[]{2, 4, 12, 20, 40});
-    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 4, 12, 20, 40});
+    public static final IntList ADVANCED_SPEEDS = new IntArrayList(new int[]{1, 2, 4, 12, 20, 40, 120, 240});
 
     private LogicMode logicMode = LogicMode.SENSOR;
     private List<Sensor> sensors = null;
@@ -126,7 +126,7 @@ public class LogicConnectorSettings extends AbstractConnectorSettings {
         advanced = gui.isAdvanced();
         String[] speeds;
         if (advanced) {
-            speeds = new String[] { "5", "10", "20", "60", "100", "200" };
+            speeds = new String[] { "5", "10", "20", "60", "100", "200", "600", "1200" };
         } else {
             speeds = new String[] { "10", "20", "60", "100", "200" };
         }

--- a/src/main/java/mcjty/xnet/blocks/cables/ConnectorBlock.java
+++ b/src/main/java/mcjty/xnet/blocks/cables/ConnectorBlock.java
@@ -446,8 +446,18 @@ public class ConnectorBlock extends GenericCableBlock implements ITileEntityProv
             tooltip.add(TextFormatting.BLUE + "machine that should be connected");
             tooltip.add(TextFormatting.BLUE + "to the network");
             boolean advanced = this == NetCableSetup.advancedConnectorBlock;
+
             int maxrf = advanced ? ConfigSetup.maxRfAdvancedConnector.get() : ConfigSetup.maxRfConnector.get();
+            int maxItem = advanced ? ConfigSetup.maxItemTransferAdvancedCached : ConfigSetup.maxItemTransferNormalCached;
+            int maxFluid = advanced ? ConfigSetup.maxFluidTransferAdvancedCached : ConfigSetup.maxFluidTransferNormalCached;
+
+            String maxItemText = maxItem == ConfigSetup.MAX_TRANSFER_UNLIMITED ? "Unlimited" : Integer.toString(maxItem);
+            String maxFluidText = maxFluid == ConfigSetup.MAX_TRANSFER_UNLIMITED ? "Unlimited" : maxFluid + " mB";
+
             tooltip.add(TextFormatting.GRAY + "" + TextFormatting.BOLD + "Max RF: " + TextFormatting.WHITE + maxrf);
+            tooltip.add(TextFormatting.GRAY + "" + TextFormatting.BOLD + "Max Item: " + TextFormatting.WHITE + maxItemText);
+            tooltip.add(TextFormatting.GRAY + "" + TextFormatting.BOLD + "Max Fluid: " + TextFormatting.WHITE + maxFluidText);
+
             if (advanced) {
                 tooltip.add(TextFormatting.GRAY + "Allow access to different sides");
                 tooltip.add(TextFormatting.GRAY + "Supports faster item transfer");

--- a/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
@@ -117,7 +117,7 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
     private NetworkChecker networkChecker = null;
 
     public TileEntityController() {
-        super(ConfigSetup.controllerMaxRF.get(), ConfigSetup.controllerRfPerTick.get());
+        super(ConfigSetup.controllerMaxRF.get(), ConfigSetup.controllerMaxRF.get());
         for (int i = 0; i < MAX_CHANNELS; i++) {
             channels[i] = null;
         }

--- a/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
@@ -117,7 +117,7 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
     private NetworkChecker networkChecker = null;
 
     public TileEntityController() {
-        super(ConfigSetup.controllerMaxRF.get(), ConfigSetup.controllerMaxRF.get());
+        super(ConfigSetup.controllerMaxRF.get(), ConfigSetup.controllerRfPerTick.get());
         for (int i = 0; i < MAX_CHANNELS; i++) {
             channels[i] = null;
         }

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/AbstractEditorPanel.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/AbstractEditorPanel.java
@@ -414,22 +414,22 @@ public abstract class AbstractEditorPanel implements IEditorGui {
         }
     }
 
-    private void wheelOnItemFilter(int amount, String tag, BlockRenderFilter blockRender)  {
+    private void wheelOnItemFilter(int amount, String tag, BlockRenderFilter blockRender) {
         ItemStack stack = (ItemStack) blockRender.getRenderItem();
-        if (stack == null)
+        if (stack == null) {
             return;
+        }
 
         alterStackCount(stack, amount > 0);
-        if (stack.getCount() <= 0)
-        {
-            update(tag, ItemStack.EMPTY);
-            blockRender.setRenderItem(null);
+
+        // Mouse wheel should never clear the ghost filter.
+        // It is too easy to accidentally scroll the wrong direction while editing counts.
+        if (stack.getCount() <= 0) {
+            stack.setCount(1);
         }
-        else
-        {
-            update(tag, stack);
-            blockRender.setRenderItem(stack);
-        }
+
+        update(tag, stack);
+        blockRender.setRenderItem(stack);
     }
 
     private void alterStackCount(ItemStack stack, boolean increase)

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -83,6 +83,7 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
     private List<SidedPos> connectorPositions = new ArrayList<>();
     private int listDirty;
     private TextField searchBar;
+    private String rememberedSearchText = "";
 
     private int delayedSelectedChannel = -1;
     private int delayedSelectedLine = -1;
@@ -198,18 +199,22 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
     @Override
     public void initGui() {
         // JEI can temporarily replace this screen and then return to the same
-        // GuiController instance. Preserve the selected connector across re-init.
+        // GuiController instance. Preserve the selected connector and search text across re-init.
         SidedPos previousEditingConnector = editingConnector;
         int previousEditingChannel = editingChannel;
+        String previousSearchText = searchBar == null ? rememberedSearchText : searchBar.getText();
 
         openController = this;
-
         xnetSideHelpWindow = null;
 
         window = new Window(this, tileEntity, XNetMessages.INSTANCE, new ResourceLocation(XNet.MODID, "gui/controller.gui"));
         super.initGui();
+
         initializeFields();
         setupEvents();
+
+        rememberedSearchText = previousSearchText == null ? "" : previousSearchText;
+        searchBar.setText(rememberedSearchText);
 
         if (previousEditingConnector != null && previousEditingChannel >= 0) {
             editingConnector = previousEditingConnector;
@@ -230,7 +235,11 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
     }
 
     private void setupEvents() {
-        window.event("searchbar", (source, params) -> { needsRefresh = true; });
+        window.event("searchbar", (source, params) -> {
+            rememberedSearchText = searchBar.getText();
+            needsRefresh = true;
+        });
+
         for (int i = 0 ; i < MAX_CHANNELS ; i++) {
             String channel = "channel" + (i+1);
             int finalI = i;

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -28,6 +28,7 @@ import mcjty.xnet.api.gui.IndicatorIcon;
 import mcjty.xnet.api.keys.SidedConsumer;
 import mcjty.xnet.api.keys.SidedPos;
 import mcjty.xnet.blocks.controller.TileEntityController;
+import mcjty.xnet.blocks.generic.GenericXNetGuiContainer;
 import mcjty.xnet.clientinfo.ChannelClientInfo;
 import mcjty.xnet.clientinfo.ConnectedBlockClientInfo;
 import mcjty.xnet.clientinfo.ConnectorClientInfo;
@@ -48,6 +49,16 @@ import net.minecraft.util.text.TextFormatting;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
+import mcjty.lib.varia.ItemStackList;
+import mcjty.xnet.apiimpl.fluids.FluidConnectorSettings;
+import mcjty.xnet.compat.jei.XNetJeiFluidFilterCollector;
+import mcjty.lib.typed.Key;
+import mcjty.lib.typed.Type;
+import mcjty.xnet.api.channels.IConnectorSettings;
+import mcjty.xnet.apiimpl.items.ItemConnectorSettings;
+import mcjty.xnet.compat.jei.XNetJeiItemFilterCollector;
+
+import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -57,11 +68,13 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
+import static mcjty.xnet.apiimpl.items.ItemConnectorSettings.*;
 import static mcjty.xnet.blocks.controller.TileEntityController.*;
 import static mcjty.xnet.logic.ChannelInfo.MAX_CHANNELS;
 
-public class GuiController extends GenericGuiContainer<TileEntityController> {
+public class GuiController extends GenericXNetGuiContainer<TileEntityController> {
 
     public static final String TAG_ENABLED = "enabled";
     public static final String TAG_NAME = "name";
@@ -90,6 +103,7 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
 
     private EnergyBar energyBar;
     private Button copyConnector = null;
+    private Window xnetSideHelpWindow = null;
 
     // From server.
     public static List<ChannelClientInfo> fromServer_channels = null;
@@ -107,16 +121,107 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
         openController = null;
     }
 
+    private static List<ItemStack> mergeItemFilters(ItemStackList existingFilters, List<ItemStack> addedFilters) {
+        List<ItemStack> merged = new ArrayList<>();
+
+        for (ItemStack stack : existingFilters) {
+            if (!stack.isEmpty()) {
+                merged.add(stack.copy());
+            }
+        }
+
+        for (ItemStack stack : addedFilters) {
+            if (!stack.isEmpty()) {
+                mergeExactItemFilter(merged, stack);
+            }
+        }
+
+        return merged;
+    }
+
+    private static void mergeExactItemFilter(List<ItemStack> merged, ItemStack stack) {
+        for (ItemStack existing : merged) {
+            if (ItemStack.areItemsEqual(existing, stack)
+                    && ItemStack.areItemStackTagsEqual(existing, stack)) {
+                existing.setCount(Math.max(existing.getCount(), stack.getCount()));
+                return;
+            }
+        }
+
+        merged.add(stack.copy());
+    }
+
+    private static List<ItemStack> mergeFluidFilters(ItemStackList existingFilters, List<ItemStack> addedFilters) {
+        List<ItemStack> merged = new ArrayList<>();
+
+        for (ItemStack stack : existingFilters) {
+            if (!stack.isEmpty()) {
+                merged.add(stack.copy());
+            }
+        }
+
+        for (ItemStack stack : addedFilters) {
+            if (!stack.isEmpty()) {
+                mergeExactItemFilter(merged, stack);
+            }
+        }
+
+        return merged;
+    }
+
+    @Override
+    protected void registerWindows(WindowManager mgr) {
+        super.registerWindows(mgr);
+
+        if (xnetSideHelpWindow == null) {
+            xnetSideHelpWindow = createXNetSideHelpWindow();
+        }
+
+        mgr.addWindow(xnetSideHelpWindow);
+    }
+
+    @Override
+    public List<Rectangle> getSideWindowBounds() {
+        List<Rectangle> bounds = new ArrayList<>(super.getSideWindowBounds());
+
+        if (xnetSideHelpWindow == null) {
+            xnetSideHelpWindow = createXNetSideHelpWindow();
+        }
+
+        if (xnetSideHelpWindow.getToplevel() != null) {
+            bounds.add(xnetSideHelpWindow.getToplevel().getBounds());
+        }
+
+        return bounds;
+    }
+
     @Override
     public void initGui() {
+        // JEI can temporarily replace this screen and then return to the same
+        // GuiController instance. Preserve the selected connector across re-init.
+        SidedPos previousEditingConnector = editingConnector;
+        int previousEditingChannel = editingChannel;
+
+        openController = this;
+
+        xnetSideHelpWindow = null;
+
         window = new Window(this, tileEntity, XNetMessages.INSTANCE, new ResourceLocation(XNet.MODID, "gui/controller.gui"));
         super.initGui();
-
         initializeFields();
         setupEvents();
 
-        editingConnector = null;
-        editingChannel = -1;
+        if (previousEditingConnector != null && previousEditingChannel >= 0) {
+            editingConnector = previousEditingConnector;
+            editingChannel = previousEditingChannel;
+
+            delayedSelectedConnector = previousEditingConnector;
+            delayedSelectedChannel = previousEditingChannel;
+            delayedSelectedLine = -1;
+        } else {
+            editingConnector = null;
+            editingChannel = -1;
+        }
 
         refresh();
         listDirty = 0;
@@ -138,6 +243,11 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
         connectorEditPanel = window.findChild("connectoreditpanel");
 
         searchBar = window.findChild("searchbar");
+        searchBar.setTooltips(
+                TextFormatting.GREEN + "Search connected blocks and connector names",
+                TextFormatting.WHITE + "Prefix " + TextFormatting.YELLOW + "!" + TextFormatting.WHITE + " to search connector names only",
+                TextFormatting.WHITE + "Use " + TextFormatting.YELLOW + "!" + TextFormatting.WHITE + " alone to show all named connectors"
+        );
         connectorList = window.findChild("connectors");
 
         connectorList.addSelectionEvent(new DefaultSelectionEvent() {
@@ -159,15 +269,14 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
     }
 
     private void hilightSelectedContainer(int index) {
-        if (index < 0) {
+        if (index < 0 || index >= connectorPositions.size()) {
             return;
         }
-        ConnectedBlockClientInfo c = fromServer_connectedBlocks.get(index);
-        if (c != null) {
-            XNet.instance.clientInfo.hilightBlock(c.getPos().getPos(), System.currentTimeMillis() + 1000 * 5);
-            Logging.message(mc.player, "The block is now highlighted");
-            //mc.player.closeScreen();
-        }
+
+        SidedPos sidedPos = connectorPositions.get(index);
+        XNet.instance.clientInfo.hilightBlock(sidedPos.getPos(), System.currentTimeMillis() + 1000 * 5);
+        Logging.message(mc.player, "The block is now highlighted");
+        //mc.player.closeScreen();
     }
 
     @Override
@@ -537,9 +646,11 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
 
                     ConnectorEditorPanel editor = new ConnectorEditorPanel(connectorEditPanel, mc, this, editingChannel, editingConnector);
 
-                    connectorInfo.getConnectorSettings().createGui(editor);
+                    IConnectorSettings connectorSettings = connectorInfo.getConnectorSettings();
+
+                    connectorSettings.createGui(editor);
                     connectorEditPanel.addChild(remove);
-                    editor.setState(connectorInfo.getConnectorSettings());
+                    editor.setState(connectorSettings);
                 } else {
                     Button create = new Button(mc, this)
                             .setText("Create")
@@ -586,6 +697,28 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
         return -1;
     }
 
+    private boolean matchesSearch(String selectedText, String blockName, String connectorName) {
+        if (selectedText.isEmpty()) {
+            return true;
+        }
+
+        String lowerConnectorName = connectorName == null ? "" : connectorName.toLowerCase();
+
+        if (selectedText.startsWith("!")) {
+            String connectorSearch = selectedText.substring(1).trim();
+
+            // Typing only "!" shows all named connectors.
+            if (connectorSearch.isEmpty()) {
+                return !lowerConnectorName.isEmpty();
+            }
+
+            return lowerConnectorName.contains(connectorSearch);
+        }
+
+        String lowerBlockName = blockName == null ? "" : blockName.toLowerCase();
+
+        return lowerBlockName.contains(selectedText) || lowerConnectorName.contains(selectedText);
+    }
     private void populateList() {
         if (!listsReady()) {
             return;
@@ -613,12 +746,11 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
             int color = StyleConfig.colorTextInListNormal;
 
             Panel panel = new Panel(mc, this).setLayout(new HorizontalLayout().setHorizontalMargin(0).setSpacing(0));
-            if (!selectedText.isEmpty()) {
-                if (!blockName.toLowerCase().contains(selectedText)) {
-                    connectorPositions.add(sidedPos);
-                    continue;
-                }
+
+            if (!matchesSearch(selectedText, blockName, name)) {
+                continue;
             }
+
             BlockRender br;
             if (coordinate.equals(prevPos)) {
                 br = new BlockRender(mc, this);
@@ -662,11 +794,24 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
             connectorPositions.add(sidedPos);
         }
 
+        if (sel >= connectorList.getChildCount()) {
+            sel = connectorList.getChildCount() - 1;
+        }
+
         connectorList.setSelected(sel);
-        if (delayedSelectedChannel != -1) {
-            connectorList.setSelected(delayedSelectedLine);
+
+        if (delayedSelectedChannel != -1 && delayedSelectedConnector != null) {
+            int line = findConnectorListIndex(delayedSelectedConnector);
+
+            if (line >= 0 && line < connectorList.getChildCount()) {
+                connectorList.setSelected(line);
+            } else if (delayedSelectedLine >= 0 && delayedSelectedLine < connectorList.getChildCount()) {
+                connectorList.setSelected(delayedSelectedLine);
+            }
+
             selectConnectorEditor(delayedSelectedConnector, delayedSelectedChannel);
         }
+
         delayedSelectedChannel = -1;
         delayedSelectedLine = -1;
         delayedSelectedConnector = null;
@@ -756,5 +901,318 @@ public class GuiController extends GenericGuiContainer<TileEntityController> {
         }
         else
             super.handleMouseClick(slotIn, slotId, mouseButton, type);
+    }
+
+    @Nullable
+    private ItemConnectorSettings getEditingItemConnectorSettings() {
+        if (!listsReady()) {
+            return null;
+        }
+
+        if (editingConnector == null || editingChannel < 0) {
+            return null;
+        }
+
+        ChannelClientInfo info = fromServer_channels.get(editingChannel);
+        if (info == null) {
+            return null;
+        }
+
+        ConnectorClientInfo clientInfo = findClientInfo(info, editingConnector);
+        if (clientInfo == null) {
+            return null;
+        }
+
+        IConnectorSettings settings = clientInfo.getConnectorSettings();
+        if (!(settings instanceof ItemConnectorSettings)) {
+            return null;
+        }
+
+        return (ItemConnectorSettings) settings;
+    }
+
+    @Nullable
+    private FluidConnectorSettings getEditingFluidConnectorSettings() {
+        if (!listsReady()) {
+            return null;
+        }
+
+        if (editingConnector == null || editingChannel < 0) {
+            return null;
+        }
+
+        ChannelClientInfo info = fromServer_channels.get(editingChannel);
+        if (info == null) {
+            return null;
+        }
+
+        ConnectorClientInfo clientInfo = findClientInfo(info, editingConnector);
+        if (clientInfo == null) {
+            return null;
+        }
+
+        IConnectorSettings settings = clientInfo.getConnectorSettings();
+        if (!(settings instanceof FluidConnectorSettings)) {
+            return null;
+        }
+
+        return (FluidConnectorSettings) settings;
+    }
+
+    public boolean canSetJeiRecipeFilters() {
+        return getEditingItemConnectorSettings() != null
+                || getEditingFluidConnectorSettings() != null;
+    }
+
+    @Nullable
+    public ItemConnectorSettings.ItemMode getJeiRecipeFilterItemMode() {
+        ItemConnectorSettings settings = getEditingItemConnectorSettings();
+        return settings == null ? null : settings.getItemMode();
+    }
+
+    @Nullable
+    public FluidConnectorSettings.FluidMode getJeiRecipeFilterFluidMode() {
+        FluidConnectorSettings settings = getEditingFluidConnectorSettings();
+        return settings == null ? null : settings.getFluidMode();
+    }
+
+    public int getJeiRecipeFilterLimit() {
+        if (getEditingItemConnectorSettings() != null) {
+            return ItemConnectorSettings.FILTER_SIZE;
+        }
+
+        if (getEditingFluidConnectorSettings() != null) {
+            return FluidConnectorSettings.FILTER_SIZE;
+        }
+
+        return 0;
+    }
+
+    public void setJeiRecipeFilters(XNetJeiItemFilterCollector.Result result) {
+        List<ItemStack> addedFilters = result.getFilters();
+        ItemConnectorSettings settings = getEditingItemConnectorSettings();
+
+        if (settings == null) {
+            showError("Select an item connector first!");
+            return;
+        }
+
+        List<ItemStack> filters = mergeItemFilters(settings.getFilters(), addedFilters);
+
+        if (addedFilters.isEmpty()) {
+            showError(result.isOutputs() ? "Recipe has no item outputs!" : "Recipe has no item inputs!");
+            return;
+        }
+
+        if (filters.size() > ItemConnectorSettings.FILTER_SIZE) {
+            showError("Recipe needs " + filters.size()
+                    + " filters after merging, but this connector supports "
+                    + ItemConnectorSettings.FILTER_SIZE + "!");
+            return;
+        }
+
+        TypedMap.Builder builder = TypedMap.builder()
+                .put(PARAM_CHANNEL, editingChannel)
+                .put(PARAM_POS, editingConnector.getPos())
+                .put(PARAM_SIDE, editingConnector.getSide().ordinal());
+
+        putString(builder, TAG_MODE, settings.getItemMode().name().toLowerCase(Locale.ROOT));
+        putString(builder, TAG_STACK, settings.getStackMode().name().toLowerCase(Locale.ROOT));
+        putString(builder, TAG_EXTRACT, settings.getExtractMode().name().toLowerCase(Locale.ROOT));
+        putString(builder, TAG_SPEED, Integer.toString(settings.getSpeed() * 5));
+
+        putBoolean(builder, TAG_BLACKLIST, settings.isBlacklist());
+        putBoolean(builder, TAG_OREDICT, settings.isOredictMode());
+
+        if (result.isAdvanced()) {
+            putBoolean(builder, TAG_COUNTMODE,
+                    settings.getItemMode() == ItemConnectorSettings.ItemMode.INS || settings.isCountMode());
+
+            putBoolean(builder, TAG_META, settings.isMetaMode() || result.needsMeta());
+            putBoolean(builder, TAG_NBT, settings.isNbtMode() || result.needsNbt());
+        } else {
+            putBoolean(builder, TAG_COUNTMODE, settings.isCountMode());
+            putBoolean(builder, TAG_META, settings.isMetaMode());
+            putBoolean(builder, TAG_NBT, settings.isNbtMode());
+        }
+
+        if (settings.getCount() != null) {
+            putInteger(builder, TAG_COUNT, settings.getCount());
+        }
+
+        if (settings.getExtractAmountSetting() != null) {
+            putInteger(builder, TAG_EXTRACT_AMOUNT, settings.getExtractAmountSetting());
+        }
+
+        putInteger(builder, TAG_PRIORITY, settings.getPriority());
+
+        if (settings.getSlot() != null) {
+            putInteger(builder, TAG_SLOT, settings.getSlot());
+        }
+
+        for (int i = 0; i < ItemConnectorSettings.FILTER_SIZE; i++) {
+            ItemStack stack = i < filters.size() ? filters.get(i).copy() : ItemStack.EMPTY;
+            putItemStack(builder, TAG_FILTER + i, stack);
+        }
+
+        rememberSelectedConnectorAfterRefresh();
+
+        sendServerCommand(XNetMessages.INSTANCE, TileEntityController.CMD_UPDATECONNECTOR, builder.build());
+        refresh();
+    }
+
+    public void setJeiFluidRecipeFilters(XNetJeiFluidFilterCollector.Result result) {
+        List<ItemStack> addedFilters = result.getFilters();
+        FluidConnectorSettings settings = getEditingFluidConnectorSettings();
+
+        if (settings == null) {
+            showError("Select a fluid connector first!");
+            return;
+        }
+
+        List<ItemStack> filters = mergeFluidFilters(settings.getFilters(), addedFilters);
+
+        if (addedFilters.isEmpty()) {
+            showError(result.isOutputs() ? "Recipe has no fluid outputs!" : "Recipe has no fluid inputs!");
+            return;
+        }
+
+        if (filters.size() > FluidConnectorSettings.FILTER_SIZE) {
+            showError("Recipe needs " + filters.size()
+                    + " filters after merging, but this connector supports "
+                    + FluidConnectorSettings.FILTER_SIZE + "!");
+            return;
+        }
+
+        TypedMap.Builder builder = TypedMap.builder()
+                .put(PARAM_CHANNEL, editingChannel)
+                .put(PARAM_POS, editingConnector.getPos())
+                .put(PARAM_SIDE, editingConnector.getSide().ordinal());
+
+        putString(builder, FluidConnectorSettings.TAG_MODE,
+                settings.getFluidMode().name().toLowerCase(Locale.ROOT));
+        putString(builder, FluidConnectorSettings.TAG_SPEED,
+                Integer.toString(settings.getSpeed() * 10));
+
+        putString(builder, FluidConnectorSettings.TAG_EXTRACT,
+                settings.getExtractMode().name().toLowerCase(Locale.ROOT));
+        putString(builder, FluidConnectorSettings.TAG_AMOUNTMODE,
+                settings.getAmountMode().name().toLowerCase(Locale.ROOT));
+
+        putBoolean(builder, FluidConnectorSettings.TAG_BLACKLIST, settings.isBlacklist());
+        putInteger(builder, FluidConnectorSettings.TAG_PRIORITY, settings.getPriority());
+
+        if (settings.getRate() != null) {
+            putInteger(builder, FluidConnectorSettings.TAG_RATE, settings.getRate());
+        }
+
+        if (settings.getMinmax() != null) {
+            putInteger(builder, FluidConnectorSettings.TAG_MINMAX, settings.getMinmax());
+        }
+
+        if (settings.getExtractTank() != null) {
+            putInteger(builder, FluidConnectorSettings.TAG_TANK, settings.getExtractTank());
+        }
+
+        for (int i = 0; i < FluidConnectorSettings.FILTER_SIZE; i++) {
+            ItemStack stack = i < filters.size() ? filters.get(i).copy() : ItemStack.EMPTY;
+            putItemStack(builder, FluidConnectorSettings.TAG_FILTER + i, stack);
+        }
+
+        rememberSelectedConnectorAfterRefresh();
+
+        sendServerCommand(XNetMessages.INSTANCE, TileEntityController.CMD_UPDATECONNECTOR, builder.build());
+        refresh();
+    }
+
+    private static void putString(TypedMap.Builder builder, String name, String value) {
+        builder.put(new Key<>(name, Type.STRING), value);
+    }
+
+    private static void putBoolean(TypedMap.Builder builder, String name, boolean value) {
+        builder.put(new Key<>(name, Type.BOOLEAN), value);
+    }
+
+    private static void putInteger(TypedMap.Builder builder, String name, int value) {
+        builder.put(new Key<>(name, Type.INTEGER), value);
+    }
+
+    private static void putItemStack(TypedMap.Builder builder, String name, ItemStack value) {
+        builder.put(new Key<>(name, Type.ITEMSTACK), value);
+    }
+
+    private void rememberSelectedConnectorAfterRefresh() {
+        if (editingConnector == null || editingChannel < 0) {
+            return;
+        }
+
+        delayedSelectedChannel = editingChannel;
+        delayedSelectedConnector = editingConnector;
+        delayedSelectedLine = findConnectorListIndex(editingConnector);
+    }
+
+    private int findConnectorListIndex(SidedPos sidedPos) {
+        for (int i = 0; i < connectorPositions.size(); i++) {
+            if (sidedPos.equals(connectorPositions.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Window createXNetSideHelpWindow() {
+        Button jeiHelpButton = new Button(mc, this)
+                .setText("J")
+                .setLayoutHint(new PositionalLayout.PositionalHint(1, 1, 16, 16))
+                .setTooltips(
+                        TextFormatting.GREEN + "JEI recipe fill",
+                        "",
+                        TextFormatting.YELLOW + "Selected INS connector",
+                        TextFormatting.WHITE + "  + adds inputs to filters",
+                        "",
+                        TextFormatting.YELLOW + "Selected EXT connector",
+                        TextFormatting.WHITE + "  + adds outputs to filters",
+                        "",
+                        TextFormatting.YELLOW + "Normal fill (+)",
+                        TextFormatting.WHITE + "  Uses 1x representative stacks",
+                        "",
+                        TextFormatting.YELLOW + "Advanced item fill (Shift +)",
+                        TextFormatting.WHITE + "  Uses recipe stack counts",
+                        TextFormatting.WHITE + "  Enables Meta/NBT if needed",
+                        TextFormatting.WHITE + "  INS also forces Count mode ON"
+                );
+
+        Button filterHelpButton = new Button(mc, this)
+                .setText("F")
+                .setLayoutHint(new PositionalLayout.PositionalHint(1, 19, 16, 16))
+                .setTooltips(
+                        TextFormatting.GREEN + "Filter count controls",
+                        "",
+                        TextFormatting.YELLOW + "Mouse wheel",
+                        TextFormatting.WHITE + "  Wheel: +/- 1",
+                        TextFormatting.WHITE + "  Ctrl + wheel: double / halve",
+                        "",
+                        TextFormatting.YELLOW + "Click count edit",
+                        TextFormatting.WHITE + "  Shift/Alt + left click: + count",
+                        TextFormatting.WHITE + "  Shift/Alt + right click: - count",
+                        TextFormatting.WHITE + "  Add Ctrl: double / halve"
+                );
+
+        Panel sidePanel = new Panel(mc, this)
+                .setLayout(new PositionalLayout())
+                .addChild(jeiHelpButton)
+                .addChild(filterHelpButton);
+
+        int sideLeft = guiLeft + xSize;
+
+        // McJtyLib's [?]/[s] side window is centered here:
+        int mcjtySideTop = guiTop + (ySize - 20) / 2 - 8;
+
+        // Put [J]/[F] directly above it.
+        int sideTop = mcjtySideTop - 40;
+
+        sidePanel.setBounds(new Rectangle(sideLeft, sideTop, 20, 40));
+
+        return new Window(this, sidePanel);
     }
 }

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -5,7 +5,6 @@ import com.google.gson.JsonParser;
 import mcjty.lib.base.StyleConfig;
 import mcjty.lib.client.RenderHelper;
 import mcjty.lib.container.GenericContainer;
-import mcjty.lib.gui.GenericGuiContainer;
 import mcjty.lib.gui.Window;
 import mcjty.lib.gui.WindowManager;
 import mcjty.lib.gui.events.ButtonEvent;
@@ -57,7 +56,7 @@ import mcjty.lib.typed.Type;
 import mcjty.xnet.api.channels.IConnectorSettings;
 import mcjty.xnet.apiimpl.items.ItemConnectorSettings;
 import mcjty.xnet.compat.jei.XNetJeiItemFilterCollector;
-import yalter.mousetweaks.api.MouseTweaksDisableWheelTweak;
+import yalter.mousetweaks.api.MouseTweaksIgnore;
 
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
@@ -75,7 +74,7 @@ import static mcjty.xnet.apiimpl.items.ItemConnectorSettings.*;
 import static mcjty.xnet.blocks.controller.TileEntityController.*;
 import static mcjty.xnet.logic.ChannelInfo.MAX_CHANNELS;
 
-@MouseTweaksDisableWheelTweak
+@MouseTweaksIgnore
 public class GuiController extends GenericXNetGuiContainer<TileEntityController> {
 
     public static final String TAG_ENABLED = "enabled";

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -57,6 +57,7 @@ import mcjty.lib.typed.Type;
 import mcjty.xnet.api.channels.IConnectorSettings;
 import mcjty.xnet.apiimpl.items.ItemConnectorSettings;
 import mcjty.xnet.compat.jei.XNetJeiItemFilterCollector;
+import yalter.mousetweaks.api.MouseTweaksDisableWheelTweak;
 
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
@@ -74,6 +75,7 @@ import static mcjty.xnet.apiimpl.items.ItemConnectorSettings.*;
 import static mcjty.xnet.blocks.controller.TileEntityController.*;
 import static mcjty.xnet.logic.ChannelInfo.MAX_CHANNELS;
 
+@MouseTweaksDisableWheelTweak
 public class GuiController extends GenericXNetGuiContainer<TileEntityController> {
 
     public static final String TAG_ENABLED = "enabled";

--- a/src/main/java/mcjty/xnet/blocks/generic/GenericXNetGuiContainer.java
+++ b/src/main/java/mcjty/xnet/blocks/generic/GenericXNetGuiContainer.java
@@ -1,0 +1,84 @@
+package mcjty.xnet.blocks.generic;
+
+import mcjty.lib.base.ModBase;
+import mcjty.lib.gui.GenericGuiContainer;
+import mcjty.lib.tileentity.GenericTileEntity;
+import net.minecraft.inventory.Container;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class GenericXNetGuiContainer<T extends GenericTileEntity> extends GenericGuiContainer<T> {
+
+    public GenericXNetGuiContainer(ModBase mod,
+                                   SimpleNetworkWrapper network,
+                                   T tileEntity,
+                                   Container container,
+                                   int manual,
+                                   String manualNode) {
+        super(mod, network, tileEntity, container, manual, manualNode);
+    }
+
+    @Override
+    public List<Rectangle> getSideWindowBounds() {
+        List<Rectangle> areas = new ArrayList<>(super.getSideWindowBounds());
+        addMainWindowExtraAreas(areas);
+        return areas;
+    }
+
+    private void addMainWindowExtraAreas(List<Rectangle> areas) {
+        if (window == null || window.getToplevel() == null) {
+            return;
+        }
+
+        Rectangle bounds = window.getToplevel().getBounds();
+
+        int normalLeft = guiLeft;
+        int normalTop = guiTop;
+        int normalRight = guiLeft + xSize;
+        int normalBottom = guiTop + ySize;
+
+        int boundsLeft = bounds.x;
+        int boundsTop = bounds.y;
+        int boundsRight = bounds.x + bounds.width;
+        int boundsBottom = bounds.y + bounds.height;
+
+        if (boundsLeft < normalLeft) {
+            areas.add(new Rectangle(
+                    boundsLeft,
+                    boundsTop,
+                    normalLeft - boundsLeft,
+                    bounds.height
+            ));
+        }
+
+        if (boundsRight > normalRight) {
+            areas.add(new Rectangle(
+                    normalRight,
+                    boundsTop,
+                    boundsRight - normalRight,
+                    bounds.height
+            ));
+        }
+
+        if (boundsTop < normalTop) {
+            areas.add(new Rectangle(
+                    normalLeft,
+                    boundsTop,
+                    xSize,
+                    normalTop - boundsTop
+            ));
+        }
+
+        if (boundsBottom > normalBottom) {
+            areas.add(new Rectangle(
+                    normalLeft,
+                    normalBottom,
+                    xSize,
+                    boundsBottom - normalBottom
+            ));
+        }
+    }
+}

--- a/src/main/java/mcjty/xnet/blocks/router/GuiRouter.java
+++ b/src/main/java/mcjty/xnet/blocks/router/GuiRouter.java
@@ -1,7 +1,6 @@
 package mcjty.xnet.blocks.router;
 
 import mcjty.lib.container.GenericContainer;
-import mcjty.lib.gui.GenericGuiContainer;
 import mcjty.lib.gui.Window;
 import mcjty.lib.gui.layout.HorizontalLayout;
 import mcjty.lib.gui.layout.PositionalLayout;
@@ -10,6 +9,7 @@ import mcjty.lib.typed.TypedMap;
 import mcjty.lib.varia.BlockPosTools;
 import mcjty.xnet.XNet;
 import mcjty.xnet.api.channels.IChannelType;
+import mcjty.xnet.blocks.generic.GenericXNetGuiContainer;
 import mcjty.xnet.clientinfo.ControllerChannelClientInfo;
 import mcjty.xnet.setup.GuiProxy;
 import mcjty.xnet.network.PacketGetLocalChannelsRouter;
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static mcjty.xnet.blocks.router.TileEntityRouter.*;
 
-public class GuiRouter extends GenericGuiContainer<TileEntityRouter> {
+public class GuiRouter extends GenericXNetGuiContainer<TileEntityRouter> {
 
     private WidgetList localChannelList;
     private WidgetList remoteChannelList;

--- a/src/main/java/mcjty/xnet/blocks/wireless/GuiWirelessRouter.java
+++ b/src/main/java/mcjty/xnet/blocks/wireless/GuiWirelessRouter.java
@@ -1,14 +1,14 @@
 package mcjty.xnet.blocks.wireless;
 
 import mcjty.lib.container.GenericContainer;
-import mcjty.lib.gui.GenericGuiContainer;
 import mcjty.lib.gui.Window;
 import mcjty.xnet.XNet;
+import mcjty.xnet.blocks.generic.GenericXNetGuiContainer;
 import mcjty.xnet.setup.GuiProxy;
 import mcjty.xnet.network.XNetMessages;
 import net.minecraft.util.ResourceLocation;
 
-public class GuiWirelessRouter extends GenericGuiContainer<TileEntityWirelessRouter> {
+public class GuiWirelessRouter extends GenericXNetGuiContainer<TileEntityWirelessRouter> {
 
     public GuiWirelessRouter(TileEntityWirelessRouter router, GenericContainer container) {
         super(XNet.instance, XNetMessages.INSTANCE, router, container, GuiProxy.GUI_MANUAL_XNET, "wireless_router");

--- a/src/main/java/mcjty/xnet/clientinfo/ConnectorInfo.java
+++ b/src/main/java/mcjty/xnet/clientinfo/ConnectorInfo.java
@@ -17,6 +17,7 @@ public class ConnectorInfo {
         this.id = id;
         this.advanced = advanced;
         connectorSettings = type.createConnector(id.getSide().getOpposite());
+        connectorSettings.sanitizeSettings(advanced);
     }
 
     public IChannelType getType() {
@@ -41,5 +42,6 @@ public class ConnectorInfo {
 
     public void readFromNBT(NBTTagCompound tag) {
         connectorSettings.readFromNBT(tag);
+        connectorSettings.sanitizeSettings(advanced);
     }
 }

--- a/src/main/java/mcjty/xnet/compat/jei/XNetFilterTransferHandler.java
+++ b/src/main/java/mcjty/xnet/compat/jei/XNetFilterTransferHandler.java
@@ -1,0 +1,142 @@
+package mcjty.xnet.compat.jei;
+
+import mcjty.lib.container.GenericContainer;
+import mcjty.xnet.apiimpl.fluids.FluidConnectorSettings;
+import mcjty.xnet.apiimpl.items.ItemConnectorSettings;
+import mcjty.xnet.blocks.controller.gui.GuiController;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import mezz.jei.gui.recipes.RecipesGui;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class XNetFilterTransferHandler implements IRecipeTransferHandler<GenericContainer> {
+
+    private final IRecipeTransferHandlerHelper helper;
+
+    public XNetFilterTransferHandler(IRecipeTransferHandlerHelper helper) {
+        this.helper = helper;
+    }
+
+    @Override
+    public Class<GenericContainer> getContainerClass() {
+        return GenericContainer.class;
+    }
+
+    @Nullable
+    @Override
+    public IRecipeTransferError transferRecipe(GenericContainer container,
+                                               IRecipeLayout recipeLayout,
+                                               EntityPlayer player,
+                                               boolean maxTransfer,
+                                               boolean doTransfer) {
+        GuiController gui = findParentControllerGui();
+
+        if (gui == null) {
+            return helper.createInternalError();
+        }
+
+        if (!gui.canSetJeiRecipeFilters()) {
+            return helper.createUserErrorWithTooltip("Select an item or fluid connector first");
+        }
+
+        ItemConnectorSettings.ItemMode itemMode = gui.getJeiRecipeFilterItemMode();
+        if (itemMode != null) {
+            XNetJeiItemFilterCollector.Mode mode = maxTransfer
+                    ? XNetJeiItemFilterCollector.Mode.ADVANCED
+                    : XNetJeiItemFilterCollector.Mode.NORMAL;
+
+            XNetJeiItemFilterCollector.Target target =
+                    itemMode == ItemConnectorSettings.ItemMode.EXT
+                            ? XNetJeiItemFilterCollector.Target.OUTPUTS
+                            : XNetJeiItemFilterCollector.Target.INPUTS;
+
+            XNetJeiItemFilterCollector.Result result =
+                    XNetJeiItemFilterCollector.collect(recipeLayout, mode, target);
+
+            List<ItemStack> filters = result.getFilters();
+
+            if (filters.isEmpty()) {
+                return helper.createUserErrorWithTooltip(
+                        target == XNetJeiItemFilterCollector.Target.OUTPUTS
+                                ? "Recipe has no item outputs"
+                                : "Recipe has no item inputs"
+                );
+            }
+
+            int limit = gui.getJeiRecipeFilterLimit();
+            if (filters.size() > limit) {
+                return helper.createUserErrorWithTooltip(
+                        "Recipe needs " + filters.size() + " filters, but this connector supports " + limit
+                );
+            }
+
+            if (doTransfer) {
+                gui.setJeiRecipeFilters(result);
+            }
+
+            return null;
+        }
+
+        FluidConnectorSettings.FluidMode fluidMode = gui.getJeiRecipeFilterFluidMode();
+        if (fluidMode != null) {
+            XNetJeiFluidFilterCollector.Target target =
+                    fluidMode == FluidConnectorSettings.FluidMode.EXT
+                            ? XNetJeiFluidFilterCollector.Target.OUTPUTS
+                            : XNetJeiFluidFilterCollector.Target.INPUTS;
+
+            XNetJeiFluidFilterCollector.Result result =
+                    XNetJeiFluidFilterCollector.collect(recipeLayout, target);
+
+            List<ItemStack> filters = result.getFilters();
+
+            if (filters.isEmpty()) {
+                return helper.createUserErrorWithTooltip(
+                        target == XNetJeiFluidFilterCollector.Target.OUTPUTS
+                                ? "Recipe has no fluid outputs"
+                                : "Recipe has no fluid inputs"
+                );
+            }
+
+            int limit = gui.getJeiRecipeFilterLimit();
+            if (filters.size() > limit) {
+                return helper.createUserErrorWithTooltip(
+                        "Recipe needs " + filters.size() + " filters, but this connector supports " + limit
+                );
+            }
+
+            if (doTransfer) {
+                gui.setJeiFluidRecipeFilters(result);
+            }
+
+            return null;
+        }
+
+        return helper.createUserErrorWithTooltip("Select an item or fluid connector first");
+    }
+
+    @Nullable
+    private static GuiController findParentControllerGui() {
+        GuiScreen screen = Minecraft.getMinecraft().currentScreen;
+
+        if (screen instanceof GuiController) {
+            return (GuiController) screen;
+        }
+
+        if (screen instanceof RecipesGui) {
+            GuiScreen parent = ((RecipesGui) screen).getParentScreen();
+            if (parent instanceof GuiController) {
+                return (GuiController) parent;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/mcjty/xnet/compat/jei/XNetJeiFluidFilterCollector.java
+++ b/src/main/java/mcjty/xnet/compat/jei/XNetJeiFluidFilterCollector.java
@@ -1,0 +1,124 @@
+package mcjty.xnet.compat.jei;
+
+import mcjty.lib.varia.FluidTools;
+import mezz.jei.api.gui.IGuiIngredient;
+import mezz.jei.api.gui.IRecipeLayout;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class XNetJeiFluidFilterCollector {
+
+    public enum Target {
+        INPUTS,
+        OUTPUTS
+    }
+
+    public static final class Result {
+        private final Target target;
+        private final List<ItemStack> filters;
+
+        private Result(Target target, List<ItemStack> filters) {
+            this.target = target;
+            this.filters = Collections.unmodifiableList(filters);
+        }
+
+        public boolean isInputs() {
+            return target == Target.INPUTS;
+        }
+
+        public boolean isOutputs() {
+            return target == Target.OUTPUTS;
+        }
+
+        public List<ItemStack> getFilters() {
+            return filters;
+        }
+    }
+
+    private XNetJeiFluidFilterCollector() {
+    }
+
+    public static Result collect(IRecipeLayout recipeLayout, Target target) {
+        List<ItemStack> merged = new ArrayList<>();
+        boolean wantInputs = target == Target.INPUTS;
+
+        Map<Integer, ? extends IGuiIngredient<FluidStack>> ingredients =
+                recipeLayout.getFluidStacks().getGuiIngredients();
+
+        for (IGuiIngredient<FluidStack> ingredient : ingredients.values()) {
+            if (ingredient.isInput() != wantInputs) {
+                continue;
+            }
+
+            FluidStack fluidStack = getDisplayedOrFirst(ingredient);
+            if (fluidStack == null) {
+                continue;
+            }
+
+            ItemStack bucket = toFilterBucket(fluidStack);
+            if (bucket.isEmpty()) {
+                continue;
+            }
+
+            mergeByFluid(merged, bucket);
+        }
+
+        return new Result(target, merged);
+    }
+
+    private static FluidStack getDisplayedOrFirst(IGuiIngredient<FluidStack> ingredient) {
+        FluidStack displayed = ingredient.getDisplayedIngredient();
+
+        if (displayed != null) {
+            return displayed.copy();
+        }
+
+        for (FluidStack candidate : ingredient.getAllIngredients()) {
+            if (candidate != null) {
+                return candidate.copy();
+            }
+        }
+
+        return null;
+    }
+
+    private static ItemStack toFilterBucket(FluidStack fluidStack) {
+        FluidStack copy = fluidStack.copy();
+
+        // A bucket filter is only an identity reference. Make sure there is
+        // enough fluid for normal bucket conversion even if JEI shows <1000mb.
+        if (copy.amount < 1000) {
+            copy.amount = 1000;
+        }
+
+        ItemStack bucket = FluidTools.convertFluidToBucket(copy);
+        if (!bucket.isEmpty()) {
+            bucket.setCount(1);
+        }
+
+        return bucket;
+    }
+
+    private static void mergeByFluid(List<ItemStack> merged, ItemStack bucket) {
+        FluidStack fluid = FluidTools.convertBucketToFluid(bucket);
+        if (fluid == null) {
+            return;
+        }
+
+        for (ItemStack existing : merged) {
+            FluidStack existingFluid = FluidTools.convertBucketToFluid(existing);
+            if (existingFluid != null && existingFluid.isFluidEqual(fluid)) {
+                return;
+            }
+        }
+
+        ItemStack copy = bucket.copy();
+        copy.setCount(1);
+        merged.add(copy);
+    }
+}

--- a/src/main/java/mcjty/xnet/compat/jei/XNetJeiItemFilterCollector.java
+++ b/src/main/java/mcjty/xnet/compat/jei/XNetJeiItemFilterCollector.java
@@ -1,0 +1,199 @@
+package mcjty.xnet.compat.jei;
+
+import mezz.jei.api.gui.IGuiIngredient;
+import mezz.jei.api.gui.IRecipeLayout;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class XNetJeiItemFilterCollector {
+
+    private static final int MAX_FILTER_STACK_COUNT = 4096;
+
+    public enum Mode {
+        NORMAL,
+        ADVANCED
+    }
+
+    public enum Target {
+        INPUTS,
+        OUTPUTS
+    }
+
+    public static final class Result {
+        private final Mode mode;
+        private final Target target;
+        private final List<ItemStack> filters;
+        private final boolean needsMeta;
+        private final boolean needsNbt;
+
+        private Result(Mode mode, Target target, List<ItemStack> filters, boolean needsMeta, boolean needsNbt) {
+            this.mode = mode;
+            this.target = target;
+            this.filters = Collections.unmodifiableList(filters);
+            this.needsMeta = needsMeta;
+            this.needsNbt = needsNbt;
+        }
+
+        public boolean isAdvanced() {
+            return mode == Mode.ADVANCED;
+        }
+
+        public boolean isInputs() {
+            return target == Target.INPUTS;
+        }
+
+        public boolean isOutputs() {
+            return target == Target.OUTPUTS;
+        }
+
+        public List<ItemStack> getFilters() {
+            return filters;
+        }
+
+        public boolean needsMeta() {
+            return needsMeta;
+        }
+
+        public boolean needsNbt() {
+            return needsNbt;
+        }
+    }
+
+    private XNetJeiItemFilterCollector() {
+    }
+
+    public static Result collect(IRecipeLayout recipeLayout, Mode mode, Target target) {
+        List<ItemStack> merged = new ArrayList<>();
+        boolean needsMeta = false;
+        boolean needsNbt = false;
+
+        boolean wantInputs = target == Target.INPUTS;
+
+        Map<Integer, ? extends IGuiIngredient<ItemStack>> ingredients =
+                recipeLayout.getItemStacks().getGuiIngredients();
+
+        for (IGuiIngredient<ItemStack> ingredient : ingredients.values()) {
+            if (ingredient.isInput() != wantInputs) {
+                continue;
+            }
+
+            ItemStack stack = getDisplayedOrFirst(ingredient);
+            if (stack.isEmpty()) {
+                continue;
+            }
+
+            if (mode == Mode.ADVANCED) {
+                if (stack.hasTagCompound()) {
+                    needsNbt = true;
+                }
+
+                if (ingredientNeedsMeta(ingredient, stack)) {
+                    needsMeta = true;
+                }
+
+                stack.setCount(clamp(stack.getCount()));
+                mergeAdvanced(merged, stack);
+            } else {
+                stack.setCount(1);
+                mergeNormal(merged, stack);
+            }
+        }
+
+        return new Result(mode, target, merged, needsMeta, needsNbt);
+    }
+
+    private static ItemStack getDisplayedOrFirst(IGuiIngredient<ItemStack> ingredient) {
+        ItemStack displayed = ingredient.getDisplayedIngredient();
+
+        if (displayed != null && !displayed.isEmpty()) {
+            return displayed.copy();
+        }
+
+        for (ItemStack candidate : ingredient.getAllIngredients()) {
+            if (candidate != null && !candidate.isEmpty()) {
+                return candidate.copy();
+            }
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    private static void mergeNormal(List<ItemStack> merged, ItemStack stack) {
+        for (ItemStack existing : merged) {
+            if (sameExactFilterTarget(existing, stack)) {
+                existing.setCount(1);
+                return;
+            }
+        }
+
+        ItemStack copy = stack.copy();
+        copy.setCount(1);
+        merged.add(copy);
+    }
+
+    private static void mergeAdvanced(List<ItemStack> merged, ItemStack stack) {
+        for (ItemStack existing : merged) {
+            if (sameExactFilterTarget(existing, stack)) {
+                existing.setCount(clamp(existing.getCount() + stack.getCount()));
+                return;
+            }
+        }
+
+        ItemStack copy = stack.copy();
+        copy.setCount(clamp(copy.getCount()));
+        merged.add(copy);
+    }
+
+    private static boolean sameExactFilterTarget(ItemStack a, ItemStack b) {
+        return ItemStack.areItemsEqual(a, b)
+                && ItemStack.areItemStackTagsEqual(a, b);
+    }
+
+    private static boolean ingredientNeedsMeta(IGuiIngredient<ItemStack> ingredient, ItemStack selected) {
+        if (selected.isEmpty()) {
+            return false;
+        }
+
+        if (!selected.getItem().getHasSubtypes()) {
+            return false;
+        }
+
+        int selectedMeta = selected.getMetadata();
+
+        if (selectedMeta == OreDictionary.WILDCARD_VALUE) {
+            return false;
+        }
+
+        boolean sawAlternative = false;
+
+        for (ItemStack alternative : ingredient.getAllIngredients()) {
+            if (alternative == null || alternative.isEmpty()) {
+                continue;
+            }
+
+            sawAlternative = true;
+
+            if (alternative.getItem() == selected.getItem()) {
+                int alternativeMeta = alternative.getMetadata();
+
+                if (alternativeMeta == OreDictionary.WILDCARD_VALUE || alternativeMeta != selectedMeta) {
+                    return false;
+                }
+            }
+        }
+
+        return sawAlternative;
+    }
+
+    private static int clamp(int count) {
+        if (count <= 0) {
+            return 1;
+        }
+        return Math.min(count, MAX_FILTER_STACK_COUNT);
+    }
+}

--- a/src/main/java/mcjty/xnet/compat/jei/XNetJeiPlugin.java
+++ b/src/main/java/mcjty/xnet/compat/jei/XNetJeiPlugin.java
@@ -1,0 +1,22 @@
+package mcjty.xnet.compat.jei;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.IModRegistry;
+import mezz.jei.api.JEIPlugin;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
+import mezz.jei.config.Constants;
+
+@JEIPlugin
+public class XNetJeiPlugin implements IModPlugin {
+
+    @Override
+    public void register(IModRegistry registry) {
+        IRecipeTransferHandlerHelper helper =
+                registry.getJeiHelpers().recipeTransferHandlerHelper();
+
+        registry.getRecipeTransferRegistry().addRecipeTransferHandler(
+                new XNetFilterTransferHandler(helper),
+                Constants.UNIVERSAL_RECIPE_TRANSFER_UID
+        );
+    }
+}

--- a/src/main/java/mcjty/xnet/config/ConfigSetup.java
+++ b/src/main/java/mcjty/xnet/config/ConfigSetup.java
@@ -15,6 +15,7 @@ public class ConfigSetup {
     public static final String CATEGORY_GENERAL = "general";
 
     public static ConfigSpec.IntValue controllerMaxRF;
+    public static ConfigSpec.IntValue controllerRfPerTick;
 
     public static ConfigSpec.IntValue wirelessRouterMaxRF;
     public static ConfigSpec.IntValue wirelessRouterRfPerTick;
@@ -60,6 +61,9 @@ public class ConfigSetup {
         controllerMaxRF = SERVER_BUILDER
                 .comment("Maximum RF the controller can store")
                 .defineInRange("controllerMaxRF", 100000, 1, 1000000000);
+        controllerRfPerTick = SERVER_BUILDER
+                .comment("Maximum RF the controller can receive per tick")
+                .defineInRange("controllerRfPerTick", 1000, 1, 1000000000);
         wirelessRouterMaxRF = SERVER_BUILDER
                 .comment("Maximum RF the wireless router can store")
                 .defineInRange("wirelessRouterMaxRF", 100000, 1, 1000000000);

--- a/src/main/java/mcjty/xnet/config/ConfigSetup.java
+++ b/src/main/java/mcjty/xnet/config/ConfigSetup.java
@@ -27,6 +27,24 @@ public class ConfigSetup {
     public static ConfigSpec.IntValue maxRfRateNormal;
     public static ConfigSpec.IntValue maxRfRateAdvanced;
 
+    public static final int MAX_TRANSFER_UNLIMITED = Integer.MAX_VALUE;
+
+    public static ConfigSpec.IntValue maxItemTransferNormal;
+    public static ConfigSpec.IntValue maxItemTransferAdvanced;
+    public static ConfigSpec.IntValue maxFluidTransferNormal;
+    public static ConfigSpec.IntValue maxFluidTransferAdvanced;
+
+    // Cached primitive values. No allocation, no GC, no per transfer look-up.
+    public static int maxItemTransferNormalCached = MAX_TRANSFER_UNLIMITED;
+    public static int maxItemTransferAdvancedCached = MAX_TRANSFER_UNLIMITED;
+    public static int maxFluidTransferNormalCached = MAX_TRANSFER_UNLIMITED;
+    public static int maxFluidTransferAdvancedCached = MAX_TRANSFER_UNLIMITED;
+
+    // Fast-path booleans.
+    // In the default case, these are false, so channel code exits immediately.
+    public static boolean itemTransferCapsEnabled = false;
+    public static boolean fluidTransferCapsEnabled = false;
+
     public static ConfigSpec.IntValue controllerRFT;          // RF per tick that the controller uses all the time
     public static ConfigSpec.IntValue controllerChannelRFT;   // RF Per tick per enabled channel
     public static ConfigSpec.IntValue controllerOperationRFT; // RF Per tick per operation
@@ -93,6 +111,21 @@ public class ConfigSetup {
         maxRfRateAdvanced = SERVER_BUILDER
                 .comment("Maximum RF/rate that an advanced connector can input or output")
                 .defineInRange("maxRfRateAdvanced", 100000, 1, 1000000000);
+        maxItemTransferNormal = SERVER_BUILDER
+                .comment("Global maximum number of items transferred per operation by a normal item connector. Applies to all item transfer modes, including Highest. Default is unlimited.")
+                .defineInRange("maxItemTransferNormal", MAX_TRANSFER_UNLIMITED, 1, MAX_TRANSFER_UNLIMITED);
+
+        maxItemTransferAdvanced = SERVER_BUILDER
+                .comment("Global maximum number of items transferred per operation by an advanced item connector. Applies to all item transfer modes, including Highest. Default is unlimited.")
+                .defineInRange("maxItemTransferAdvanced", MAX_TRANSFER_UNLIMITED, 1, MAX_TRANSFER_UNLIMITED);
+
+        maxFluidTransferNormal = SERVER_BUILDER
+                .comment("Global maximum amount of fluid in mB transferred per operation by a normal fluid connector. Applies to all fluid transfer modes, including Highest. Default is unlimited.")
+                .defineInRange("maxFluidTransferNormal", MAX_TRANSFER_UNLIMITED, 1, MAX_TRANSFER_UNLIMITED);
+
+        maxFluidTransferAdvanced = SERVER_BUILDER
+                .comment("Global maximum amount of fluid in mB transferred per operation by an advanced fluid connector. Applies to all fluid transfer modes, including Highest. Default is unlimited.")
+                .defineInRange("maxFluidTransferAdvanced", MAX_TRANSFER_UNLIMITED, 1, MAX_TRANSFER_UNLIMITED);
         maxPublishedChannels = SERVER_BUILDER
                 .comment("Maximum number of published channels that a routing channel can support")
                 .defineInRange("maxPublishedChannels", 32, 1, 1000000000);
@@ -123,9 +156,22 @@ public class ConfigSetup {
 
     public static ConfigSpec SERVER_CONFIG;
     public static ConfigSpec CLIENT_CONFIG;
-
-
     public static Configuration mainConfig;
+
+    public static void syncCachedValues() {
+        maxItemTransferNormalCached = maxItemTransferNormal.get();
+        maxItemTransferAdvancedCached = maxItemTransferAdvanced.get();
+        maxFluidTransferNormalCached = maxFluidTransferNormal.get();
+        maxFluidTransferAdvancedCached = maxFluidTransferAdvanced.get();
+
+        itemTransferCapsEnabled =
+                maxItemTransferNormalCached != MAX_TRANSFER_UNLIMITED ||
+                        maxItemTransferAdvancedCached != MAX_TRANSFER_UNLIMITED;
+
+        fluidTransferCapsEnabled =
+                maxFluidTransferNormalCached != MAX_TRANSFER_UNLIMITED ||
+                        maxFluidTransferAdvancedCached != MAX_TRANSFER_UNLIMITED;
+    }
 
     public static void init() {
         mainConfig = new Configuration(new File(XNet.setup.getModConfigDir().getPath() + File.separator + "xnet", "xnet.cfg"));
@@ -134,6 +180,7 @@ public class ConfigSetup {
             cfg.load();
             SERVER_CONFIG = SERVER_BUILDER.build(mainConfig);
             CLIENT_CONFIG = CLIENT_BUILDER.build(mainConfig);
+            syncCachedValues();
         } catch (Exception e1) {
             FMLLog.log(Level.ERROR, e1, "Problem loading config file!");
         }

--- a/src/main/java/mcjty/xnet/config/ConfigSetup.java
+++ b/src/main/java/mcjty/xnet/config/ConfigSetup.java
@@ -15,7 +15,6 @@ public class ConfigSetup {
     public static final String CATEGORY_GENERAL = "general";
 
     public static ConfigSpec.IntValue controllerMaxRF;
-    public static ConfigSpec.IntValue controllerRfPerTick;
 
     public static ConfigSpec.IntValue wirelessRouterMaxRF;
     public static ConfigSpec.IntValue wirelessRouterRfPerTick;
@@ -26,9 +25,6 @@ public class ConfigSetup {
 
     public static ConfigSpec.IntValue maxRfRateNormal;
     public static ConfigSpec.IntValue maxRfRateAdvanced;
-
-    public static ConfigSpec.IntValue maxFluidRateNormal;
-    public static ConfigSpec.IntValue maxFluidRateAdvanced;
 
     public static ConfigSpec.IntValue controllerRFT;          // RF per tick that the controller uses all the time
     public static ConfigSpec.IntValue controllerChannelRFT;   // RF Per tick per enabled channel
@@ -64,9 +60,6 @@ public class ConfigSetup {
         controllerMaxRF = SERVER_BUILDER
                 .comment("Maximum RF the controller can store")
                 .defineInRange("controllerMaxRF", 100000, 1, 1000000000);
-        controllerRfPerTick = SERVER_BUILDER
-                .comment("Maximum RF the controller can receive per tick")
-                .defineInRange("controllerRfPerTick", 1000, 1, 1000000000);
         wirelessRouterMaxRF = SERVER_BUILDER
                 .comment("Maximum RF the wireless router can store")
                 .defineInRange("wirelessRouterMaxRF", 100000, 1, 1000000000);
@@ -96,13 +89,6 @@ public class ConfigSetup {
         maxRfRateAdvanced = SERVER_BUILDER
                 .comment("Maximum RF/rate that an advanced connector can input or output")
                 .defineInRange("maxRfRateAdvanced", 100000, 1, 1000000000);
-        maxFluidRateNormal = SERVER_BUILDER
-                .comment("Maximum fluid per operation that a normal connector can input or output")
-                .defineInRange("maxFluidRateNormal", 1000, 1, 1000000000);
-        maxFluidRateAdvanced = SERVER_BUILDER
-                .comment("Maximum fluid per operation that an advanced connector can input or output")
-                .defineInRange("maxFluidRateAdvanced", 5000, 1, 1000000000);
-
         maxPublishedChannels = SERVER_BUILDER
                 .comment("Maximum number of published channels that a routing channel can support")
                 .defineInRange("maxPublishedChannels", 32, 1, 1000000000);


### PR DESCRIPTION
1.8.19
- Added 600 and 1200 timings to item/fluid/logic channels
- Aligned Fluidchannel with itemchannel semantics
  - Simple staggering to avoid silent failures when multiple inserts hit the same
fluidhandler on same tick.
- Added JEI/HEI recipe fill support for item and fluid connector filters
    - Insert connectors add recipe inputs; extract connectors add recipe outputs
    - Shift + uses advanced/count-aware item fill
    - Fill is additive and preserves existing filters/settings
- Added JEI and filter-control help buttons to the controller GUI
- Improved JEI return behavior to preserve:
  - last selected connector open
  - search text field
- Added proper GUI exclusionzone for JEI
- Prevented mouse-wheel count editing from accidentally clearing ghost filters
- Disabled Mousetweak's WheelTweak for Controller. Repairs scrolling.
- Search by connectornames in controllerGUI.
- Config-entries: max limits for Normal/Advanced item and fluid connectors
  - Print maxes on connector tooltip