### PR TITLE
Avoid mutating fluid tank contents during extraction (compatability with old fluidhandlers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.8.20
+- Fix fluid duping with old fluidhandlers (IC2++)
+
 1.8.19
 - Added 600 and 1200 timings to item/fluid/logic channels
 - Aligned Fluidchannel with itemchannel semantics

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 // Project properties
 group = "eladidu.xnet"
-version = "1.8.19"
+version = "1.8.20"
 
 // Set the toolchain version to decouple the Java we run Gradle with from the Java used to compile and run the mod
 java {

--- a/src/main/java/mcjty/xnet/XNet.java
+++ b/src/main/java/mcjty/xnet/XNet.java
@@ -31,7 +31,7 @@ public class XNet implements ModBase {
 
     public static final String MODID = "xnet";
     public static final String MODNAME = "XNet";
-    public static final String MODVERSION = "1.8.19";
+    public static final String MODVERSION = "1.8.20";
 
     public static final String MIN_FORGE11_VER = "13.19.0.2176";
     public static final String MIN_MCJTYLIB_VER = "3.5.0";

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidChannelSettings.java
@@ -343,9 +343,10 @@ public class FluidChannelSettings extends DefaultChannelSettings implements ICha
         FluidStack stack = tanks[idx].getContents();
         if (stack != null && tanks[idx].canDrain())
         {
-            // No need for a copy, it's already a copy from getContents().
-            stack.amount = extractAmount;
-            stack = handler.drain(stack, !simulate);
+            // Do not mutate getContents(); some handlers expose a live stack.
+            FluidStack request = stack.copy();
+            request.amount = Math.min(extractAmount, stack.amount);
+            stack = handler.drain(request, !simulate);
             if (stack != null && matcher.test(stack))
             {
                 return stack;


### PR DESCRIPTION
## Summary

Fixes fluid extraction mutating source tank contents.

`FluidChannelSettings#fetchFluid` modified the `FluidStack` returned by `IFluidTankProperties#getContents()`. Some (old/bad) handlers, such as IC2, can expose a mutable/live stack there, allowing simulated extraction in Highest mode to inflate the source amount.

This PR copies the contents stack before changing the drain request amount, and caps the request to the amount reported by that tank.

## Scope

This PR only fixes the mutable `getContents()`, and we only simulate what tank has to offer.

It does not change transfer ordering or other semantics.

## Notes

The original XNet code did not hit this issue because it used amount-based draining instead of mutating the `FluidStack` returned by `getContents()`.Therefore this bug did NOT exsist in XNet. For ZNet i tested only 1.8.18 and 1.8.19 with the same dupe and result:
- IC2 Matter Fabricator containing ~42 mB UU-Matter and XNet fluid extraction in all modes. Before this fix, the target could receive whatever XNet requested [mB]. After this fix, only the actual available amount is transferred.

https://github.com/Krutoy242/Enigmatica2Expert-Extended/issues/614