### PR TITLE
Cable rendering bug and Filter amount UX fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 1.8.21
-
+- Fixed logic sensor Equality / inEquality not comparing correctly
 - Fixed cable rendering issues where cables could show the wrong color
 - Fixed resource reload (F3 + T) should work correctly
 - Improved item filter count editing:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Ctrl + Shift: +/-1000
   - Alt: double / halve
 - Updated the filter help tooltip with the new count controls
+- Widen the inputfields in fluidconnectorsettings (where there is room)
 
 1.8.20
 - Fix fluid duping with old fluidhandlers (IC2++)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+1.8.21
+
+- Fixed cable rendering issues where cables could show the wrong color
+- Fixed resource reload (F3 + T) should work correctly
+- Improved item filter count editing:
+  - Shift: +/-10
+  - Ctrl: +/-100
+  - Ctrl + Shift: +/-1000
+  - Alt: double / halve
+- Updated the filter help tooltip with the new count controls
+
 1.8.20
 - Fix fluid duping with old fluidhandlers (IC2++)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 // Project properties
 group = "eladidu.xnet"
-version = "1.8.20"
+version = "1.8.21"
 
 // Set the toolchain version to decouple the Java we run Gradle with from the Java used to compile and run the mod
 java {

--- a/src/main/java/mcjty/xnet/XNet.java
+++ b/src/main/java/mcjty/xnet/XNet.java
@@ -31,7 +31,7 @@ public class XNet implements ModBase {
 
     public static final String MODID = "xnet";
     public static final String MODNAME = "XNet";
-    public static final String MODVERSION = "1.8.20";
+    public static final String MODVERSION = "1.8.21";
 
     public static final String MIN_FORGE11_VER = "13.19.0.2176";
     public static final String MIN_MCJTYLIB_VER = "3.5.0";

--- a/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/fluids/FluidConnectorSettings.java
@@ -207,12 +207,12 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
                     .toggleText(TAG_BLACKLIST, "Enable blacklist mode", "BL", blacklist).shift(2)
                     .shift(20)
                     .label("Min")
-                    .integer(TAG_MINMAX, "Keep this amount of|fluid in tank", minmax, 36)
+                    .integer(TAG_MINMAX, "Keep this amount of|fluid in tank", minmax, 68)
                     .nl();
         } else {
             gui.nl()
                     .choices(TAG_MODE, "Insert or extract mode", fluidMode, FluidMode.values())
-                    .integer(TAG_RATE, "Fluid insertion rate|per operation|(empty = max)", rate, 36)
+                    .integer(TAG_RATE, "Fluid insertion rate|per operation|(empty = max)", rate, 54)
                     .choices(TAG_SPEED, "Number of ticks for each operation", Integer.toString(speed * 10), speeds)
                     .nl()
 
@@ -222,7 +222,7 @@ public class FluidConnectorSettings extends AbstractConnectorSettings {
                     .toggleText(TAG_BLACKLIST, "Enable blacklist mode", "BL", blacklist).shift(2)
                     .shift(20)
                     .label("Max")
-                    .integer(TAG_MINMAX, "Disable insertion if|fluid level is too high", minmax, 36)
+                    .integer(TAG_MINMAX, "Disable insertion if|fluid level is too high", minmax, 66)
                     .nl();
         }
 

--- a/src/main/java/mcjty/xnet/apiimpl/logic/Sensor.java
+++ b/src/main/java/mcjty/xnet/apiimpl/logic/Sensor.java
@@ -22,7 +22,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiPredicate;
 
 import static mcjty.xnet.api.channels.Color.COLORS;
 import static mcjty.xnet.api.channels.Color.OFF;
@@ -45,15 +44,14 @@ public class Sensor {
     }
 
     public enum Operator {
-        EQUAL("=", (i1, i2) -> i1 == i2),
-        NOTEQUAL("!=", (i1, i2) -> i1 != i2),
-        LESS("<", (i1, i2) -> i1 < i2),
-        GREATER(">", (i1, i2) -> i1 > i2),
-        LESSOREQUAL("<=", (i1, i2) -> i1 <= i2),
-        GREATOROREQUAL(">=", (i1, i2) -> i1 >= i2);
+        EQUAL("="),
+        NOTEQUAL("!="),
+        LESS("<"),
+        GREATER(">"),
+        LESSOREQUAL("<="),
+        GREATOROREQUAL(">=");
 
         private final String code;
-        private final BiPredicate<Integer, Integer> matcher;
 
         private static final Map<String, Operator> OPERATOR_MAP = new HashMap<>();
 
@@ -63,9 +61,8 @@ public class Sensor {
             }
         }
 
-        Operator(String code, BiPredicate<Integer, Integer> matcher) {
+        Operator(String code) {
             this.code = code;
-            this.matcher = matcher;
         }
 
         public String getCode() {
@@ -73,7 +70,21 @@ public class Sensor {
         }
 
         public boolean match(int i1, int i2) {
-            return matcher.test(i1, i2);
+            switch (this) {
+                case EQUAL:
+                    return i1 == i2;
+                case NOTEQUAL:
+                    return i1 != i2;
+                case LESS:
+                    return i1 < i2;
+                case GREATER:
+                    return i1 > i2;
+                case LESSOREQUAL:
+                    return i1 <= i2;
+                case GREATOROREQUAL:
+                    return i1 >= i2;
+            }
+            return false;
         }
 
         @Override

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/AbstractEditorPanel.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/AbstractEditorPanel.java
@@ -26,6 +26,12 @@ public abstract class AbstractEditorPanel implements IEditorGui {
     public static final int LEFTMARGIN = 3;
     public static final int TOPMARGIN = 3;
 
+    private static final int FILTER_COUNT_STEP_NORMAL = 1;
+    private static final int FILTER_COUNT_STEP_SHIFT = 10;
+    private static final int FILTER_COUNT_STEP_CTRL = 100;
+    private static final int FILTER_COUNT_STEP_CTRL_SHIFT = 1000;
+    private static final int MAX_FILTER_COUNT = Integer.MAX_VALUE;
+
     private final Panel panel;
     private final Minecraft mc;
     private final GuiController gui;
@@ -335,8 +341,8 @@ public abstract class AbstractEditorPanel implements IEditorGui {
         // Click with empty hand
         if (holding.isEmpty())
         {
-            // Require alt or shift to alter the stack instead of deleting it
-            if (Keyboard.isKeyDown(Keyboard.KEY_LMENU) || Keyboard.isKeyDown(Keyboard.KEY_RMENU) || Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))
+            // Require a modifier (keyboard button) to alter the stack instead of deleting it.
+            if (hasFilterCountEditModifier())
             {
                 if (button == 0)
                 {
@@ -432,19 +438,61 @@ public abstract class AbstractEditorPanel implements IEditorGui {
         blockRender.setRenderItem(stack);
     }
 
-    private void alterStackCount(ItemStack stack, boolean increase)
-    {
-        int newCount = stack.getCount();
-        if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL) || Keyboard.isKeyDown(Keyboard.KEY_RCONTROL))
-        {
-            if (increase) newCount *= 2;
-            else newCount /= 2;
+    private static boolean isKeyDown(int leftKey, int rightKey) {
+        return Keyboard.isKeyDown(leftKey) || Keyboard.isKeyDown(rightKey);
+    }
+
+    private static boolean isShiftDown() {
+        return isKeyDown(Keyboard.KEY_LSHIFT, Keyboard.KEY_RSHIFT);
+    }
+
+    private static boolean isControlDown() {
+        return isKeyDown(Keyboard.KEY_LCONTROL, Keyboard.KEY_RCONTROL);
+    }
+
+    private static boolean isAltDown() {
+        return isKeyDown(Keyboard.KEY_LMENU, Keyboard.KEY_RMENU);
+    }
+
+    private static boolean hasFilterCountEditModifier() {
+        return isAltDown() || isShiftDown() || isControlDown();
+    }
+
+    private static int getFilterCountStep() {
+        boolean shift = isShiftDown();
+        boolean control = isControlDown();
+
+        if (shift && control) {
+            return FILTER_COUNT_STEP_CTRL_SHIFT;
+        } else if (control) {
+            return FILTER_COUNT_STEP_CTRL;
+        } else if (shift) {
+            return FILTER_COUNT_STEP_SHIFT;
+        } else {
+            return FILTER_COUNT_STEP_NORMAL;
         }
-        else
-        {
-            if (increase) newCount++;
-            else newCount--;
+    }
+
+    private void alterStackCount(ItemStack stack, boolean increase) {
+        long newCount = stack.getCount();
+
+        if (isAltDown()) {
+            if (increase) {
+                newCount *= 2L;
+            } else {
+                newCount /= 2L;
+            }
+        } else {
+            int step = getFilterCountStep();
+            newCount += increase ? step : -step;
         }
-        stack.setCount(newCount);
+
+        if (newCount > MAX_FILTER_COUNT) {
+            newCount = MAX_FILTER_COUNT;
+        } else if (newCount < 0) {
+            newCount = 0;
+        }
+
+        stack.setCount((int) newCount);
     }
 }

--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -1197,15 +1197,11 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
                 .setLayoutHint(new PositionalLayout.PositionalHint(1, 19, 16, 16))
                 .setTooltips(
                         TextFormatting.GREEN + "Filter count controls",
-                        "",
-                        TextFormatting.YELLOW + "Mouse wheel",
-                        TextFormatting.WHITE + "  Wheel: +/- 1",
-                        TextFormatting.WHITE + "  Ctrl + wheel: double / halve",
-                        "",
-                        TextFormatting.YELLOW + "Click count edit",
-                        TextFormatting.WHITE + "  Shift/Alt + left click: + count",
-                        TextFormatting.WHITE + "  Shift/Alt + right click: - count",
-                        TextFormatting.WHITE + "  Add Ctrl: double / halve"
+                        TextFormatting.YELLOW + "Mouse wheel / click",
+                        TextFormatting.WHITE + "  Shift: +/- 10",
+                        TextFormatting.WHITE + "  Ctrl: +/- 100",
+                        TextFormatting.WHITE + "  Ctrl + Shift: +/- 1000",
+                        TextFormatting.WHITE + "  Alt: double / halve"
                 );
 
         Panel sidePanel = new Panel(mc, this)

--- a/src/main/java/mcjty/xnet/blocks/generic/BakedModelLoader.java
+++ b/src/main/java/mcjty/xnet/blocks/generic/BakedModelLoader.java
@@ -46,6 +46,6 @@ public class BakedModelLoader implements ICustomModelLoader {
 
     @Override
     public void onResourceManagerReload(IResourceManager resourceManager) {
-
+        GenericCableBakedModel.resetTextureCache();
     }
 }

--- a/src/main/java/mcjty/xnet/blocks/generic/GenericCableBakedModel.java
+++ b/src/main/java/mcjty/xnet/blocks/generic/GenericCableBakedModel.java
@@ -31,9 +31,6 @@ public class GenericCableBakedModel implements IBakedModel {
     public static final ModelResourceLocation modelConnector = new ModelResourceLocation(XNet.MODID + ":" + ConnectorBlock.CONNECTOR);
     public static final ModelResourceLocation modelCable = new ModelResourceLocation(XNet.MODID + ":" + NetCableBlock.NETCABLE);
 
-    private TextureAtlasSprite spriteCable;
-    private TextureAtlasSprite spriteConnector;
-
     public static class CableTextures {
         TextureAtlasSprite spriteConnector;
         TextureAtlasSprite spriteAdvancedConnector;
@@ -207,15 +204,16 @@ public class GenericCableBakedModel implements IBakedModel {
         CableColor cableColor = extendedBlockState.getValue(GenericCableBlock.COLOR);
         int index = cableColor.ordinal();
 
+        GenericCableBlock block = (GenericCableBlock) state.getBlock();
+
         initTextures();
         CableTextures ct = cableTextures[index];
-        spriteCable = ct.spriteNormalCable;
-        GenericCableBlock block = (GenericCableBlock) state.getBlock();
-        if (block.isAdvancedConnector()) {
-            spriteConnector = ct.spriteAdvancedConnector;
-        } else {
-            spriteConnector = ct.spriteConnector;
-        }
+
+        TextureAtlasSprite spriteCable = ct.spriteNormalCable;
+        TextureAtlasSprite spriteConnector = block.isAdvancedConnector()
+                ? ct.spriteAdvancedConnector
+                : ct.spriteConnector;
+
         Function<CablePatterns.SpriteIdx, TextureAtlasSprite> getSprite = idx -> getSpriteNormal(idx, index);
         float hilight = 1.0f;
         if (block instanceof ConnectorBlock) {
@@ -394,7 +392,11 @@ public class GenericCableBakedModel implements IBakedModel {
 
     @Override
     public TextureAtlasSprite getParticleTexture() {
-        return spriteCable == null ? Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite() : spriteCable;
+        initTextures();
+        if (cableTextures == null || cableTextures.length == 0 || cableTextures[0] == null) {
+            return Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite();
+        }
+        return cableTextures[0].spriteNormalCable;
     }
 
     @Override
@@ -406,5 +408,4 @@ public class GenericCableBakedModel implements IBakedModel {
     public ItemOverrideList getOverrides() {
         return ItemOverrideList.NONE;
     }
-
 }

--- a/src/main/java/mcjty/xnet/blocks/generic/GenericCableBakedModel.java
+++ b/src/main/java/mcjty/xnet/blocks/generic/GenericCableBakedModel.java
@@ -399,6 +399,11 @@ public class GenericCableBakedModel implements IBakedModel {
         return cableTextures[0].spriteNormalCable;
     }
 
+    public static void resetTextureCache() {
+        cableTextures = null;
+        spriteSide = null;
+    }
+
     @Override
     public ItemCameraTransforms getItemCameraTransforms() {
         return ItemCameraTransforms.DEFAULT;


### PR DESCRIPTION
## Summary

Fixes cable rendering bugs where cables could randomly render with the wrong color or connector texture.

Fixes logic sensor equality checks by replacing boxed `Integer` lambda comparisons with primitive `int` comparisons.

Filter count:
The old double/halve was awkward for precise large values like 6000 or 10000 because it often required many final single adjustments.

Fluid connector has 4 fields (2+2 || ins+ext) where player inputs a fluid value, this inputfields now strecthes wider where there is room. All except extract rate field  (still only shows 4 numbers) now shows 7 and 9 numbers at the same time.

## Changes

- Widen the inputfields in fluidconnectorsettings (where there is room)
- Use local cable/connector sprite variables during quad generation instead of mutable baked-model fields.
- Update particle texture lookup so it no longer depends on mutable render state.
- Reset cached cable texture sprites on resource reload to avoid stale atlas references.
- Fix logic sensor `=` / `!=` comparisons for larger item, fluid, energy, and redstone values.
- Improve item filter count editing with precise modifier steps: Shift +/-10, Ctrl +/-100, Ctrl+Shift +/-1000, while keeping Alt as double/halve.
- Update the filter help tooltip to show the new count controls.

Example of broken cable textures after a resource reload (F3 + T):
<img width="380" height="512" alt="image" src="https://github.com/user-attachments/assets/1a367c0a-c15f-4d3d-94ea-f98e87bbdcca" />

Incorrect cable sprite/color rendering:
<img width="1070" height="665" alt="image" src="https://github.com/user-attachments/assets/ee6c488b-c039-4bca-bb33-a503c63894a4" />

New Tooltip showing the modes. (AE inspired modes)
<img width="244" height="133" alt="image" src="https://github.com/user-attachments/assets/8c8afa0e-7dd1-4c9c-b63b-eb5bf78a7f45" />

Especially for fluid and energy, setting sensor to X, (where target has X fluid / rf ) old code would output these results:
(which is matematically impossible, and proves = and != being wrong)
```
== is false
!= is true
<= is true
>= is true
< is false
> is false
```