### PR TITLE
Avoid connector network dirty on same-tile block swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.8.21
+- Avoid connector network dirty on same-tile block swaps
+
 1.8.20
 - Fix fluid duping with old fluidhandlers (IC2++)
 

--- a/src/main/java/mcjty/xnet/blocks/cables/ConnectorTileEntity.java
+++ b/src/main/java/mcjty/xnet/blocks/cables/ConnectorTileEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.play.server.SPacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.capabilities.Capability;
@@ -43,7 +44,8 @@ public class ConnectorTileEntity extends GenericTileEntity implements IFacadeSup
 
     private byte enabled = 0x3f;
 
-    private Block[] cachedNeighbours = new Block[EnumFacing.VALUES.length];
+    private final Block[] cachedNeighbours = new Block[EnumFacing.VALUES.length];
+    private final Class<?>[] cachedNeighbourTileClasses = new Class<?>[EnumFacing.VALUES.length];
 
     public static final Key<String> VALUE_NAME = new Key<>("name", Type.STRING);
 
@@ -134,16 +136,72 @@ public class ConnectorTileEntity extends GenericTileEntity implements IFacadeSup
         return pulseCounter;
     }
 
-    // Optimization to only increase the network if there is an actual block change
+    private static Class<?> getTileClass(TileEntity tile) {
+        return tile == null ? null : tile.getClass();
+    }
+
+    private static boolean sameTileClass(Class<?> oldTileClass, Class<?> newTileClass) {
+        return oldTileClass != null && oldTileClass == newTileClass;
+    }
+
+    private static boolean isXNetBlock(Block block) {
+        if (block == null || block.getRegistryName() == null) {
+            return false;
+        }
+
+        return block.getRegistryName().toString().startsWith("xnet:");
+    }
+
+    private static boolean shouldMarkNetworkDirty(Block oldBlock,
+                                                  Block newBlock,
+                                                  Class<?> oldTileClass,
+                                                  Class<?> newTileClass) {
+        if (oldBlock == newBlock && oldTileClass == newTileClass) {
+            return false;
+        }
+
+        // Never suppress XNet's own topology blocks. Cable/connector/controller/router
+        // changes must keep the old conservative behavior.
+        if (isXNetBlock(oldBlock) || isXNetBlock(newBlock)) {
+            return true;
+        }
+
+        // Suppress common modded active/idle block swaps when the actual tile type
+        // behind the connector did not change.
+        if (oldBlock != newBlock && sameTileClass(oldTileClass, newTileClass)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // Optimization to only increase the network version if there is an actual connector-relevant change.
     public void possiblyMarkNetworkDirty(@Nonnull BlockPos neighbor) {
+        if (world == null || world.isRemote) {
+            return;
+        }
+
         for (EnumFacing facing : EnumFacing.VALUES) {
             if (getPos().offset(facing).equals(neighbor)) {
-                Block newblock = world.getBlockState(neighbor).getBlock();
-                if (newblock != cachedNeighbours[facing.ordinal()]) {
-                    cachedNeighbours[facing.ordinal()] = newblock;
-                    WorldBlob worldBlob = XNetBlobData.getBlobData(world).getWorldBlob(world);
-                    worldBlob.markNetworkDirty(worldBlob.getNetworkAt(getPos()));
+                int side = facing.ordinal();
+
+                IBlockState newState = world.getBlockState(neighbor);
+                Block newBlock = newState.getBlock();
+                Block oldBlock = cachedNeighbours[side];
+
+                TileEntity newTile = world.getTileEntity(neighbor);
+                Class<?> newTileClass = getTileClass(newTile);
+                Class<?> oldTileClass = cachedNeighbourTileClasses[side];
+
+                cachedNeighbours[side] = newBlock;
+                cachedNeighbourTileClasses[side] = newTileClass;
+
+                if (!shouldMarkNetworkDirty(oldBlock, newBlock, oldTileClass, newTileClass)) {
+                    return;
                 }
+
+                WorldBlob worldBlob = XNetBlobData.getBlobData(world).getWorldBlob(world);
+                worldBlob.markNetworkDirty(worldBlob.getNetworkAt(getPos()));
                 return;
             }
         }


### PR DESCRIPTION
## Avoid unnecessary XNet network invalidation for same-tile block swaps

Some modded machines swap their block between active/idle variants while keeping the same `TileEntity` instance. XNet connectors currently treat that block change as a network topology change and call `markNetworkDirty`, causing controller channel caches to rebuild even though the connected endpoint did not actually change.

Example: NuclearCraft machines: Every on/off transition from one of these machines marks XNet network dirty and force cache rebuilds.

This change keeps the existing block-side neighbor cache and adds a tiny adjacent TileEntity class cache per connector side. Network dirty is suppressed when the adjacent block changes between non-XNet blocks but the adjacent TileEntity class stays the same. XNet blocks and tile class changes still use the old conservative dirty behavior.

## Spark comparison

| Metric | Old-code mean | New test | Change |
|---|---:|---:|---:|
| Total XNet `updateCache` time | 626.0 ms | 4 ms | -622.0 ms |
| `updateCache` as % of XNet channel tick | 30.0% | 0.17% | -29.83% |

## Per-channel `updateCache` comparison

| Channel | Old mean `updateCache` | Old cache % | New test6 `updateCache` | New cache % | Cache change |
|---|---:|---:|---:|---:|---:|
| Item | 522.3 ms | 27.4% | 3 ms | 0.14% | -519.3 ms |
| Fluid | 103.7 ms | 59.5% | 1 ms | 0.79% | -102.7 ms |
| Logic | 0 ms | 0.0% | 0 ms | 0.0% | 0 ms |

## `updateCache` child costs, channels combined

| Child inside `updateCache` | Old-code mean | New test6 | Change |
|---|---:|---:|---:|
| `TileEntityController.getRoutedConnectors` | 566.3 ms | 2 ms | -564.3 ms |
| `TileEntityController.getConnectors` | 221.0 ms | 2 ms | -219.0 ms |
| `HashSet.add` | 48.7 ms | 0 ms | -48.7 ms |
| `ArrayList.sort` | 33.0 ms | 1 ms | -32.0 ms |
| `ArrayList.add` | 5.3 ms | 0 ms | -5.3 ms |
| `HashMap.put` | 5.0 ms | 0 ms | -5.0 ms |
| Direct/self time in `updateCache` | ~28 ms | ~2 ms | much lower |

Note: child costs are from visible sampled call stacks and can overlap across channel profiles, so the most important comparison is the direct per-channel `updateCache`.

## Main result

This change does not rewrite channel caching. It prevents false network invalidations before they reach the controller/channel cache layer.

The measured cache churn dropped from:

| Result | Old-code mean | New test6 |
|---|---:|---:|
| Item + Fluid + Logic `updateCache` time | 626.0 ms | 4 ms |
| Item `updateCache` time | 522.3 ms | 3 ms |
| Fluid `updateCache` time | 103.7 ms | 1 ms |
| Logic `updateCache` time | 0 ms | 0 ms |

The important result for this PR is that false active/idle block swaps no longer force broad cache rebuilds for XNet channels.