### PR TITLE
keep ConnectorSelection in GUI active

### DIFF
--- a/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/gui/GuiController.java
@@ -422,6 +422,26 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
     private void selectConnectorEditor(SidedPos sidedPos, int finalI) {
         editingConnector = sidedPos;
         selectChannelEditor(finalI);
+
+        int line = findConnectorListIndex(sidedPos);
+        if (line >= 0 && line < connectorList.getChildCount()) {
+            connectorList.setSelected(line);
+        }
+    }
+
+    private void restoreConnectorListSelectionIfCleared() {
+        if (connectorList == null || editingConnector == null) {
+            return;
+        }
+
+        if (connectorList.getSelected() != -1) {
+            return;
+        }
+
+        int line = findConnectorListIndex(editingConnector);
+        if (line >= 0 && line < connectorList.getChildCount()) {
+            connectorList.setSelected(line);
+        }
     }
 
     private void refreshChannelEditor() {
@@ -835,6 +855,7 @@ public class GuiController extends GenericXNetGuiContainer<TileEntityController>
     protected void drawGuiContainerBackgroundLayer(float v, int x1, int x2) {
         requestListsIfNeeded();
         populateList();
+        restoreConnectorListSelectionIfCleared();
         refreshChannelEditor();
         refreshConnectorEditor();
         if (listsReady() && copyConnector != null && editingChannel != -1) {


### PR DESCRIPTION
keep ConnectorSelection in GUI active(dark grey) when editing ConnectorSettings.

This also allows for searching for connector, select it, blank search, and still see ur selected connector in relation to the other connectors. Much needed workflow QoL

old code loses the dark grey selection highlight when editing a selected connector.. this makes u lose track of "where u were" when working in controllerGUI